### PR TITLE
Fix: Correct parser grammar and test configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-pythonpath = .
+pythonpath = src

--- a/src/asciidoc_parser/grammar.lark
+++ b/src/asciidoc_parser/grammar.lark
@@ -52,7 +52,7 @@ sidebar_content: (admonition | example_block | basic_block)*
 text_content: inline_element+
 
 attribute_reference: LBRACE ATTR_NAME RBRACE
-?inline_element: bold | italic | monospace | attribute_reference | WORD | ATTR_NAME | LBRACE | RBRACE | WHITESPACE
+?inline_element: bold | italic | monospace | attribute_reference | WORD | WHITESPACE
 
 bold: "*" text_content "*"
 italic: "_" text_content "_"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -130,6 +130,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(literal['attributes'], {'style': 'source', 'language': 'python'})
         self.assertIn('def foo(): pass', literal['content'])
 
+    def test_section_parsing(self):
         source = "== Section 1\n\nThis is the first section.\n"
         ast = parse_to_ast(source)
         expected_ast = {


### PR DESCRIPTION
Refined the inline element grammar to be more precise, preventing partial attribute references from being parsed as valid text.

Corrected the pytest configuration to use the 'src' directory, aligning it with the project's structure. Split a malformed test into two distinct, focused tests for better clarity and maintenance.