### PR TITLE
Merge Phase 2 (Document infrastructure)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 * **Sidebar Blocks**: Implementation of `****` delimited sidebar blocks with full block nesting.
 * **Attribute Parsing**: Added generic `[...]` attribute list parsing for blocks.
 * **Source/Code Blocks**: Foundation for source blocks via `[source,lang]` attributes on literal blocks.
+* **Example Blocks**: Support for `====` delimited example blocks.
 
 === Fixed
 * Resolved `ast` module naming conflict.

--- a/README.adoc
+++ b/README.adoc
@@ -121,7 +121,7 @@ The path to 1:1 parity with Asciidoctor is tracked through the following phases:
 
 | **0** | **Foundations**: PEG grammar, structured AST, and TCK harness. | ✅
 | **1** | **Advanced Blocks**: Admonitions ✅, Sidebars ✅, Source blocks ✅, and Example blocks ✅. | ✅
-| **2** | **Document Infra**: Headers, attributes, and includes. | ⏳
+| **2** | **Document Infra**: Headers✅, attributes✅, and includes✅. | ✅
 | **3** | **Tables**: Complex layouts, spanning, and formatting. | ⏳
 | **4** | **Extensions**: Links, images, macros, and cross-references. | ⏳
 | **5** | **Preprocessing**: Conditionals and TOC generation. | ⏳

--- a/README.adoc
+++ b/README.adoc
@@ -120,7 +120,7 @@ The path to 1:1 parity with Asciidoctor is tracked through the following phases:
 | Phase | Focus | Status
 
 | **0** | **Foundations**: PEG grammar, structured AST, and TCK harness. | ✅
-| **1** | **Advanced Blocks**: Admonitions ✅, Sidebars ✅, and Source blocks ✅. | ✅
+| **1** | **Advanced Blocks**: Admonitions ✅, Sidebars ✅, Source blocks ✅, and Example blocks ✅. | ✅
 | **2** | **Document Infra**: Headers, attributes, and includes. | ⏳
 | **3** | **Tables**: Complex layouts, spanning, and formatting. | ⏳
 | **4** | **Extensions**: Links, images, macros, and cross-references. | ⏳

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-pythonpath = .
+pythonpath = src

--- a/src/asciidoc_parser/grammar.lark
+++ b/src/asciidoc_parser/grammar.lark
@@ -52,7 +52,7 @@ sidebar_content: (admonition | example_block | basic_block)*
 text_content: inline_element+
 
 attribute_reference: LBRACE ATTR_NAME RBRACE
-?inline_element: bold | italic | monospace | attribute_reference | WORD | ATTR_NAME | LBRACE | RBRACE | WHITESPACE
+?inline_element: bold | italic | monospace | attribute_reference | WORD | WHITESPACE
 
 bold: "*" text_content "*"
 italic: "_" text_content "_"

--- a/src/asciidoc_parser/grammar.lark
+++ b/src/asciidoc_parser/grammar.lark
@@ -3,7 +3,7 @@ start: document
 
 document: block*
 
-block: section | paragraph | ulist | olist | literal_block | blank_line | admonition | sidebar
+block: section | blank_line | attribute_entry | paragraph | ulist | olist | literal_block | admonition | sidebar | example_block
 
 blank_line: _NEWLINE+
 
@@ -21,6 +21,9 @@ olist: olist_item+
 ulist_item: ULIST_MARKER text_content _NEWLINE
 olist_item: OLIST_MARKER text_content _NEWLINE
 
+// Attributes
+attribute_entry: ":" ATTR_NAME ":" [WHITESPACE] [text_content] _NEWLINE
+
 // Attribute List (e.g., [source,python])
 attribute_list: "[" attribute_content "]" _NEWLINE
 attribute_content: /[^\]]+/
@@ -34,17 +37,22 @@ basic_block: literal_block | ulist | olist | paragraph | blank_line
 
 // Admonitions allow sidebars but not (implicitly) other admonitions to avoid ambiguity without delimiter size checks
 admonition: ADMONITION_START _NEWLINE ADMONITION_DELIM _NEWLINE admonition_content ADMONITION_DELIM _NEWLINE?
-admonition_content: (sidebar | basic_block)*
+admonition_content: (sidebar | example_block | basic_block)*
+
+// Example Blocks
+example_block: ADMONITION_DELIM _NEWLINE example_content ADMONITION_DELIM _NEWLINE?
+example_content: (admonition | sidebar | basic_block)*
 
 // Sidebars allow admonitions but not other sidebars
 sidebar: SIDEBAR_DELIM _NEWLINE sidebar_content SIDEBAR_DELIM _NEWLINE?
-sidebar_content: (admonition | basic_block)*
+sidebar_content: (admonition | example_block | basic_block)*
 
 // --- Inline Elements ---
 // Using a recursive definition. Requires the Earley parser.
 text_content: inline_element+
 
-?inline_element: bold | italic | monospace | WORD | WHITESPACE
+attribute_reference: LBRACE ATTR_NAME RBRACE
+?inline_element: bold | italic | monospace | attribute_reference | WORD | ATTR_NAME | LBRACE | RBRACE | WHITESPACE
 
 bold: "*" text_content "*"
 italic: "_" text_content "_"
@@ -65,9 +73,11 @@ SIDEBAR_DELIM: /\*\*\*\*/
 // Non-greedy content matching for literal blocks.
 LITERAL_BLOCK_CONTENT: /(.(?!----\n))*./s
 
-// Inline Terminals
 _NEWLINE: /(\r\n|\n|\r)/
 WHITESPACE: /[ \t]+/
-WORD: /[^ \t\n*_`=\[\]]+/  // Word characters (not whitespace or markup)
+ATTR_NAME: /[a-zA-Z0-9_\-]+/
+WORD: /[^ \t\n*_`=\[\]{}]+/  // Word characters (not whitespace or markup)
+LBRACE: "{"
+RBRACE: "}"
 
 // %ignore WHITESPACE

--- a/src/asciidoc_parser/grammar.lark
+++ b/src/asciidoc_parser/grammar.lark
@@ -1,7 +1,10 @@
 
 start: document
 
-document: block*
+document: document_header? block*
+
+document_header: document_title (attribute_entry | text_content _NEWLINE)* blank_line
+document_title: DOC_TITLE_LEAD text_content _NEWLINE
 
 block: section | blank_line | attribute_entry | paragraph | ulist | olist | literal_block | admonition | sidebar | example_block
 
@@ -62,7 +65,8 @@ monospace: "`" text_content "`"
 // --- Terminals ---
 
 // Block Terminals
-SECTION_TITLE_LEAD: /==+[ \t]*/
+DOC_TITLE_LEAD: /= [ \t]*/
+SECTION_TITLE_LEAD: /==+ [ \t]*/
 ULIST_MARKER: /(\*+|[-])[ \t]+/
 OLIST_MARKER: /([0-9]+\.|[\.]+)[ \t]+/
 LITERAL_BLOCK_DELIM.2: /----/

--- a/src/asciidoc_parser/lark_parser.py
+++ b/src/asciidoc_parser/lark_parser.py
@@ -1,10 +1,11 @@
 
 import os
+import re
 from lark import Lark, Transformer, Discard, Token
 from .nodes import (
-    Node, Document, Title, Section, Paragraph, Text, Strong, Emphasis, 
+    Node, Document, Title, Section, Paragraph, Text, Strong, Emphasis,
     InlineCode, BulletList, OrderedList, ListItem, LiteralBlock, Admonition, Sidebar, ExampleBlock,
-    AttributeEntry
+    AttributeEntry, Header, Author, Revision
 )
 from .preprocessor import Preprocessor
 
@@ -87,9 +88,56 @@ class AsciiDocTransformer(Transformer):
         self.attributes = {}
 
     def document(self, children):
-        filtered_children = [c for c in children if c is not Discard]
-        merged_children = _merge_consecutive_lists(filtered_children)
-        return Document(merged_children)
+        children = [c for c in children if c is not Discard and c is not None]
+        header = None
+        if children and isinstance(children[0], Header):
+            header = children.pop(0)
+
+        merged_children = _merge_consecutive_lists(children)
+
+        doc = Document(merged_children)
+        if header:
+            doc.header = header
+            self.attributes.update(header.attributes)
+        return doc
+
+    def document_header(self, children):
+        title = children[0]
+        author = None
+        revision = None
+
+        # Regex to match author lines (e.g., "John Doe <john.doe@example.com>")
+        author_regex = re.compile(r'[\w\s]+(<.*>)?')
+        # Regex to match revision lines (e.g., "v1.0, 2023-01-01")
+        revision_regex = re.compile(r'(v\d+\.\d+.*)|(\d{4}-\d{2}-\d{2})')
+
+        text_lines = [c for c in children[1:] if isinstance(c, list)]
+
+        if len(text_lines) > 0:
+            line1_text = "".join([node.text for node in text_lines[0] if hasattr(node, 'text')])
+            if author_regex.fullmatch(line1_text.strip()):
+                author = Author(text_lines[0])
+
+        if len(text_lines) > 1:
+            line2_text = "".join([node.text for node in text_lines[1] if hasattr(node, 'text')])
+            if revision_regex.fullmatch(line2_text.strip()):
+                revision = Revision(text_lines[1])
+
+        attributes = {}
+        for child in children:
+            if isinstance(child, AttributeEntry):
+                attributes[child.name] = self.attributes.get(child.name, [])
+
+        return Header(
+            title=title,
+            author=author,
+            revision=revision,
+            attributes=attributes
+        )
+
+    def document_title(self, children):
+        nodes = [c for c in children if isinstance(c, list)]
+        return Title(nodes[0] if nodes else [])
 
     def block(self, children):
         return children[0] if children else Discard
@@ -235,13 +283,19 @@ class AsciiDocTransformer(Transformer):
         # For the AttributeEntry node itself, create a simple string value for now.
         value_str = ""
         parts = []
-        for node in value_nodes:
+        # Ensure value_nodes is a list before iterating
+        if not isinstance(value_nodes, list):
+            value_nodes_list = [value_nodes]
+        else:
+            value_nodes_list = value_nodes
+        for node in value_nodes_list:
             if hasattr(node, 'text'):
                 parts.append(node.text)
             elif hasattr(node, 'children'):
                  # This is a bit naive but works for basic attribute values
                  parts.append("".join([child.text for child in node.children if hasattr(child, 'text')]))
         value_str = "".join(parts).strip()
+
         return AttributeEntry(name, value_str)
 
     # --- Inlines ---
@@ -253,14 +307,13 @@ class AsciiDocTransformer(Transformer):
                 name = c.value
                 break
 
-        # Return the list of nodes, or a Text node with the unresolved reference
-        return self.attributes.get(name, Text(f"{{{name}}}"))
+        # Return the list of nodes, or a list containing a Text node with the unresolved reference
+        return self.attributes.get(name, [Text(f"{{{name}}}")])
 
     def text_content(self, children):
         nodes = []
         text_buffer = ''
 
-        # Flatten the list of children, in case of attribute substitution returning a list of nodes
         flat_children = []
         for child in children:
             if isinstance(child, list):

--- a/src/asciidoc_parser/lark_parser.py
+++ b/src/asciidoc_parser/lark_parser.py
@@ -6,6 +6,7 @@ from .nodes import (
     InlineCode, BulletList, OrderedList, ListItem, LiteralBlock, Admonition, Sidebar, ExampleBlock,
     AttributeEntry
 )
+from .preprocessor import Preprocessor
 
 def _merge_consecutive_lists(blocks):
     if not blocks:
@@ -310,13 +311,17 @@ class AsciiDocTransformer(Transformer):
 
 DEFAULT_GRAMMAR = os.path.join(os.path.dirname(__file__), 'grammar.lark')
 
-def parse_to_ast(source, grammar_file=DEFAULT_GRAMMAR):
+def parse_to_ast(source, grammar_file=DEFAULT_GRAMMAR, base_dir=None):
+    # Preprocess the source to handle includes
+    preprocessor = Preprocessor(base_dir)
+    processed_source = preprocessor.process(source)
+
     with open(grammar_file, "r") as f:
         grammar = f.read()
     # Using LALR or Earley is common, but we are moving to PEG
     # For now, let's keep it compatible. PEG in Lark is experimental.
     parser = Lark(grammar, start='document', parser='earley')
-    tree = parser.parse(source)
+    tree = parser.parse(processed_source)
     ast_root = AsciiDocTransformer().transform(tree)
     # Return as dict for test compatibility
     return ast_root.to_dict() if hasattr(ast_root, 'to_dict') else ast_root

--- a/src/asciidoc_parser/lark_parser.py
+++ b/src/asciidoc_parser/lark_parser.py
@@ -376,5 +376,4 @@ def parse_to_ast(source, grammar_file=DEFAULT_GRAMMAR, base_dir=None):
     parser = Lark(grammar, start='document', parser='earley')
     tree = parser.parse(processed_source)
     ast_root = AsciiDocTransformer().transform(tree)
-    # Return as dict for test compatibility
-    return ast_root.to_dict() if hasattr(ast_root, 'to_dict') else ast_root
+    return ast_root

--- a/src/asciidoc_parser/lark_parser.py
+++ b/src/asciidoc_parser/lark_parser.py
@@ -221,24 +221,27 @@ class AsciiDocTransformer(Transformer):
 
     def attribute_entry(self, children):
         name = ""
-        value = ""
+        value_nodes = []
         for c in children:
             if isinstance(c, Token) and c.type == 'ATTR_NAME':
                 name = c.value
             elif isinstance(c, list):
-                # Simple text concatenation for now
-                parts = []
-                for node in c:
-                    if hasattr(node, 'text'):
-                        parts.append(node.text)
-                    elif hasattr(node, 'children'):
-                         # Recursively get text if it's a nested node (like Bold)
-                         # This is a bit naive but works for basic attribute values
-                         parts.append("".join([child.text for child in node.children if hasattr(child, 'text')]))
-                value = "".join(parts).strip()
-        print(f"DEBUG: AttributeEntry name='{name}' value='{value}'")
-        self.attributes[name] = value
-        return AttributeEntry(name, value)
+                value_nodes = c
+
+        # Store the rich AST nodes for later substitution
+        self.attributes[name] = value_nodes
+
+        # For the AttributeEntry node itself, create a simple string value for now.
+        value_str = ""
+        parts = []
+        for node in value_nodes:
+            if hasattr(node, 'text'):
+                parts.append(node.text)
+            elif hasattr(node, 'children'):
+                 # This is a bit naive but works for basic attribute values
+                 parts.append("".join([child.text for child in node.children if hasattr(child, 'text')]))
+        value_str = "".join(parts).strip()
+        return AttributeEntry(name, value_str)
 
     # --- Inlines ---
 
@@ -248,14 +251,23 @@ class AsciiDocTransformer(Transformer):
             if isinstance(c, Token) and c.type == 'ATTR_NAME':
                 name = c.value
                 break
-        print(f"DEBUG: AttRef lookup '{name}' in {self.attributes.keys()}")
-        value = self.attributes.get(name, f"{{{name}}}")
-        return Text(value)
+
+        # Return the list of nodes, or a Text node with the unresolved reference
+        return self.attributes.get(name, Text(f"{{{name}}}"))
 
     def text_content(self, children):
         nodes = []
         text_buffer = ''
+
+        # Flatten the list of children, in case of attribute substitution returning a list of nodes
+        flat_children = []
         for child in children:
+            if isinstance(child, list):
+                flat_children.extend(child)
+            else:
+                flat_children.append(child)
+
+        for child in flat_children:
             if isinstance(child, Token):
                 text_buffer += str(child.value)
             elif isinstance(child, Text):

--- a/src/asciidoc_parser/lark_parser.py
+++ b/src/asciidoc_parser/lark_parser.py
@@ -3,7 +3,8 @@ import os
 from lark import Lark, Transformer, Discard, Token
 from .nodes import (
     Node, Document, Title, Section, Paragraph, Text, Strong, Emphasis, 
-    InlineCode, BulletList, OrderedList, ListItem, LiteralBlock, Admonition, Sidebar
+    InlineCode, BulletList, OrderedList, ListItem, LiteralBlock, Admonition, Sidebar, ExampleBlock,
+    AttributeEntry
 )
 
 def _merge_consecutive_lists(blocks):
@@ -80,6 +81,10 @@ def _nest_list_items(items):
     return all_root_children
 
 class AsciiDocTransformer(Transformer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.attributes = {}
+
     def document(self, children):
         filtered_children = [c for c in children if c is not Discard]
         merged_children = _merge_consecutive_lists(filtered_children)
@@ -142,6 +147,18 @@ class AsciiDocTransformer(Transformer):
     def sidebar_content(self, children):
         return [c for c in children if c is not Discard]
 
+    def example_content(self, children):
+        return [c for c in children if c is not Discard]
+
+    def example_block(self, children):
+        inner = []
+        for c in children:
+            if isinstance(c, list):
+                inner = c
+                break
+        merged_inner = _merge_consecutive_lists(inner)
+        return ExampleBlock(children=merged_inner)
+
     def attribute_content(self, children):
         # returns the attribute string (e.g. "source,python")
         return children[0].value
@@ -202,7 +219,38 @@ class AsciiDocTransformer(Transformer):
         merged_inner = _merge_consecutive_lists(inner)
         return Sidebar(children=merged_inner)
 
+    def attribute_entry(self, children):
+        name = ""
+        value = ""
+        for c in children:
+            if isinstance(c, Token) and c.type == 'ATTR_NAME':
+                name = c.value
+            elif isinstance(c, list):
+                # Simple text concatenation for now
+                parts = []
+                for node in c:
+                    if hasattr(node, 'text'):
+                        parts.append(node.text)
+                    elif hasattr(node, 'children'):
+                         # Recursively get text if it's a nested node (like Bold)
+                         # This is a bit naive but works for basic attribute values
+                         parts.append("".join([child.text for child in node.children if hasattr(child, 'text')]))
+                value = "".join(parts).strip()
+        print(f"DEBUG: AttributeEntry name='{name}' value='{value}'")
+        self.attributes[name] = value
+        return AttributeEntry(name, value)
+
     # --- Inlines ---
+
+    def attribute_reference(self, children):
+        name = ""
+        for c in children:
+            if isinstance(c, Token) and c.type == 'ATTR_NAME':
+                name = c.value
+                break
+        print(f"DEBUG: AttRef lookup '{name}' in {self.attributes.keys()}")
+        value = self.attributes.get(name, f"{{{name}}}")
+        return Text(value)
 
     def text_content(self, children):
         nodes = []
@@ -210,7 +258,9 @@ class AsciiDocTransformer(Transformer):
         for child in children:
             if isinstance(child, Token):
                 text_buffer += str(child.value)
-            elif isinstance(child, (Node, dict)): # Handle both while migrating
+            elif isinstance(child, Text):
+                text_buffer += child.text
+            elif isinstance(child, Node):
                 if text_buffer:
                     nodes.append(Text(text_buffer))
                     text_buffer = ''

--- a/src/asciidoc_parser/nodes.py
+++ b/src/asciidoc_parser/nodes.py
@@ -13,54 +13,47 @@ class Node:
     def append(self, child: 'Node'):
         self.children.append(child)
 
+    _SERIALIZABLE_ATTRS = [
+        'text', 'content', 'url', 'alt', 'level',
+        'flavor', 'name', 'value'
+    ]
+    _NODE_ATTRS = ['title_node', 'header']
+
     def to_dict(self) -> dict:
         """Convert the node and its children to a dictionary (for testing)."""
-        data = {'type': self.__class__.__name__.lower()}
-        if hasattr(self, 'text'):
-            data['text'] = self.text
-        if hasattr(self, 'content'):
-            data['content'] = self.content
-        if hasattr(self, 'attributes') and self.attributes:
-            data['attributes'] = self.attributes
-        if hasattr(self, 'url'):
-            data['url'] = self.url
-        if hasattr(self, 'alt'):
-            data['alt'] = self.alt
-        if hasattr(self, 'level'):
-            data['level'] = self.level
-        if hasattr(self, 'flavor'):
-            data['flavor'] = self.flavor
-        if hasattr(self, 'name'):
-            data['name'] = self.name
-        if hasattr(self, 'value'):
-            data['value'] = self.value
-        if hasattr(self, 'title_node') and self.title_node:
-            data['title'] = self.title_node.to_dict()
-        if hasattr(self, 'header') and self.header:
-            data['header'] = self.header.to_dict()
-        
-        # Special case for dictionary-based children in original tests
-        if self.children:
-            data['children'] = [c.to_dict() for c in self.children]
+        node_type = self.__class__.__name__.lower()
         
         # Map class names to specific type strings used in old tests if they differ
         type_map = {
-            'strong': 'strong',
-            'emphasis': 'emphasis',
             'inlinecode': 'literal',
             'bulletlist': 'bullet_list',
             'orderedlist': 'enumerated_list',
-            'document': 'document',
-            'paragraph': 'paragraph',
-            'section': 'section',
-            'title': 'title',
             'listitem': 'list_item',
+            'attributeentry': 'attribute_entry',
             'literalblock': 'literal_block',
-            'sidebar': 'sidebar',
             'exampleblock': 'example_block',
-            'attributeentry': 'attribute_entry'
         }
-        data['type'] = type_map.get(data['type'], data['type'])
+        data = {'type': type_map.get(node_type, node_type)}
+
+        if hasattr(self, 'attributes') and self.attributes:
+            data['attributes'] = self.attributes
+
+        for attr in self._SERIALIZABLE_ATTRS:
+            if hasattr(self, attr):
+                value = getattr(self, attr)
+                if value is not None:
+                    data[attr] = value
+
+        for attr in self._NODE_ATTRS:
+            if hasattr(self, attr):
+                node = getattr(self, attr)
+                if node:
+                    # 'title_node' -> 'title'
+                    key = attr.replace('_node', '')
+                    data[key] = node.to_dict()
+
+        if self.children:
+            data['children'] = [c.to_dict() for c in self.children]
         
         return data
 

--- a/src/asciidoc_parser/nodes.py
+++ b/src/asciidoc_parser/nodes.py
@@ -1,3 +1,4 @@
+
 """
 Custom Abstract Syntax Tree (AST) for AsciiDoc parsing.
 """
@@ -35,6 +36,8 @@ class Node:
             data['value'] = self.value
         if hasattr(self, 'title_node') and self.title_node:
             data['title'] = self.title_node.to_dict()
+        if hasattr(self, 'header') and self.header:
+            data['header'] = self.header.to_dict()
         
         # Special case for dictionary-based children in original tests
         if self.children:
@@ -79,12 +82,43 @@ class Document(BlockNode):
     """Root node of the document."""
     def __init__(self, children: Optional[List['Node']] = None):
         super().__init__(children)
-        self.title: Optional[str] = None
+        self.header: Optional[Header] = None
         self.attributes: dict[str, str] = {}
 
 class Title(Node):
     """Represents a section title."""
     pass
+
+class Author(Node):
+    """Represents the author line in the document header."""
+    pass
+
+class Revision(Node):
+    """Represents the revision line in the document header."""
+    pass
+
+class Header(Node):
+    """Represents the document header."""
+    def __init__(self, title: Optional[Title] = None, author: Optional[Author] = None, revision: Optional[Revision] = None, attributes: Optional[Dict[str, Any]] = None):
+        super().__init__()
+        self.title = title
+        self.author = author
+        self.revision = revision
+        self.attributes = attributes or {}
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        if self.title:
+            data['title'] = self.title.to_dict()
+        if self.author:
+            data['author'] = self.author.to_dict()
+        if self.revision:
+            data['revision'] = self.revision.to_dict()
+        if self.attributes:
+            data['attributes'] = {
+                k: [v_node.to_dict() for v_node in v] for k, v in self.attributes.items()
+            }
+        return data
 
 class Section(BlockNode):
     """Represents a section with a title and content."""

--- a/src/asciidoc_parser/nodes.py
+++ b/src/asciidoc_parser/nodes.py
@@ -22,18 +22,7 @@ class Node:
     def to_dict(self) -> dict:
         """Convert the node and its children to a dictionary (for testing)."""
         node_type = self.__class__.__name__.lower()
-        
-        # Map class names to specific type strings used in old tests if they differ
-        type_map = {
-            'inlinecode': 'literal',
-            'bulletlist': 'bullet_list',
-            'orderedlist': 'enumerated_list',
-            'listitem': 'list_item',
-            'attributeentry': 'attribute_entry',
-            'literalblock': 'literal_block',
-            'exampleblock': 'example_block',
-        }
-        data = {'type': type_map.get(node_type, node_type)}
+        data = {'type': node_type}
 
         if hasattr(self, 'attributes') and self.attributes:
             data['attributes'] = self.attributes

--- a/src/asciidoc_parser/nodes.py
+++ b/src/asciidoc_parser/nodes.py
@@ -4,11 +4,41 @@ Custom Abstract Syntax Tree (AST) for AsciiDoc parsing.
 """
 
 from typing import List, Optional, Any, Dict
+from enum import Enum
+
+class NodeType(str, Enum):
+    DOCUMENT = 'document'
+    TITLE = 'title'
+    AUTHOR = 'author'
+    REVISION = 'revision'
+    HEADER = 'header'
+    SECTION = 'section'
+    PARAGRAPH = 'paragraph'
+    TEXT = 'text'
+    STRONG = 'strong'
+    EMPHASIS = 'emphasis'
+    INLINE_CODE = 'literal'
+    LINK = 'link'
+    IMAGE = 'image'
+    BULLET_LIST = 'bullet_list'
+    ORDERED_LIST = 'enumerated_list'
+    LIST_ITEM = 'list_item'
+    LITERAL_BLOCK = 'literal_block'
+    EXAMPLE_BLOCK = 'example_block'
+    QUOTE_BLOCK = 'quote_block'
+    ADMONITION = 'admonition'
+    SIDEBAR = 'sidebar'
+    TABLE = 'table'
+    TABLE_ROW = 'table_row'
+    TABLE_CELL = 'table_cell'
+    ATTRIBUTE_ENTRY = 'attribute_entry'
+    INCLUDE = 'include'
 
 class Node:
     """Base class for all AST nodes."""
     def __init__(self, children: Optional[List['Node']] = None):
         self.children: List[Node] = children or []
+        self.node_type: Optional[NodeType] = None
 
     def append(self, child: 'Node'):
         self.children.append(child)
@@ -21,8 +51,7 @@ class Node:
 
     def to_dict(self) -> dict:
         """Convert the node and its children to a dictionary (for testing)."""
-        node_type = self.__class__.__name__.lower()
-        data = {'type': node_type}
+        data = {'type': self.node_type.value}
 
         if hasattr(self, 'attributes') and self.attributes:
             data['attributes'] = self.attributes
@@ -64,25 +93,33 @@ class Document(BlockNode):
     """Root node of the document."""
     def __init__(self, children: Optional[List['Node']] = None):
         super().__init__(children)
+        self.node_type = NodeType.DOCUMENT
         self.header: Optional[Header] = None
         self.attributes: dict[str, str] = {}
 
 class Title(Node):
     """Represents a section title."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.TITLE
 
 class Author(Node):
     """Represents the author line in the document header."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.AUTHOR
 
 class Revision(Node):
     """Represents the revision line in the document header."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.REVISION
 
 class Header(Node):
     """Represents the document header."""
     def __init__(self, title: Optional[Title] = None, author: Optional[Author] = None, revision: Optional[Revision] = None, attributes: Optional[Dict[str, Any]] = None):
         super().__init__()
+        self.node_type = NodeType.HEADER
         self.title = title
         self.author = author
         self.revision = revision
@@ -106,36 +143,46 @@ class Section(BlockNode):
     """Represents a section with a title and content."""
     def __init__(self, level: int, title_node: Node):
         super().__init__()
+        self.node_type = NodeType.SECTION
         self.level = level
         self.title_node = title_node
 
 class Paragraph(BlockNode):
     """Represents a paragraph of text."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.PARAGRAPH
 
 class Text(InlineNode):
     """Represents a plain text segment."""
     def __init__(self, text: str):
         super().__init__()
+        self.node_type = NodeType.TEXT
         self.text = text
 
 class Strong(InlineNode):
     """Represents bold text."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.STRONG
 
 class Emphasis(InlineNode):
     """Represents italicized text."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.EMPHASIS
 
 class InlineCode(InlineNode):
     """Represents inline code."""
     def __init__(self, children: Optional[List['Node']] = None):
         super().__init__(children)
+        self.node_type = NodeType.INLINE_CODE
 
 class Link(InlineNode):
     """Represents a hyperlink."""
     def __init__(self, url: str, text: Optional[str] = None):
         super().__init__()
+        self.node_type = NodeType.LINK
         self.url = url
         self.text = text or url
 
@@ -143,50 +190,66 @@ class Image(InlineNode):
     """Represents an image."""
     def __init__(self, url: str, alt: str = ""):
         super().__init__()
+        self.node_type = NodeType.IMAGE
         self.url = url
         self.alt = alt
 
 class BulletList(BlockNode):
     """Represents an unordered list."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.BULLET_LIST
 
 class OrderedList(BlockNode):
     """Represents an ordered list."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.ORDERED_LIST
 
 class ListItem(BlockNode):
     """Represents an item in a list."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.LIST_ITEM
 
 class LiteralBlock(BlockNode):
     """Represents a literal block (e.g., code block)."""
     def __init__(self, content: str, attributes: Optional[Dict[str, Any]] = None):
         super().__init__()
+        self.node_type = NodeType.LITERAL_BLOCK
         self.content = content
         self.attributes = attributes or {}
 
 class ExampleBlock(BlockNode):
     """Represents an example block."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.EXAMPLE_BLOCK
 
 class QuoteBlock(BlockNode):
     """Represents a block quote."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.QUOTE_BLOCK
 
 class Admonition(BlockNode):
     """Represents an admonition block (e.g., NOTE, TIP)."""
     def __init__(self, flavor: str, children: Optional[List['Node']] = None):
         super().__init__(children)
+        self.node_type = NodeType.ADMONITION
         self.flavor = flavor
 
 class Sidebar(BlockNode):
     """Represents a sidebar block."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.SIDEBAR
 
 class Table(BlockNode):
     """Represents a table."""
     def __init__(self):
         super().__init__()
+        self.node_type = NodeType.TABLE
         self.header_rows: List[TableRow] = []
         self.rows: List[TableRow] = []
 
@@ -194,16 +257,20 @@ class TableRow(Node):
     """Represents a row in a table."""
     def __init__(self):
         super().__init__()
+        self.node_type = NodeType.TABLE_ROW
         self.cells: List[TableCell] = []
 
 class TableCell(Node):
     """Represents a cell in a table."""
-    pass
+    def __init__(self, children: Optional[List['Node']] = None):
+        super().__init__(children)
+        self.node_type = NodeType.TABLE_CELL
 
 class AttributeEntry(Node):
     """Represents a document attribute."""
     def __init__(self, name: str, value: str):
         super().__init__()
+        self.node_type = NodeType.ATTRIBUTE_ENTRY
         self.name = name
         self.value = value
 
@@ -211,7 +278,7 @@ class Include(Node):
     """Represents an include directive."""
     def __init__(self, filename: str):
         super().__init__()
-        self.filename = filename
+        self.node_type = NodeType.INCLUDE
 
 class NodeVisitor:
     """Base class for visiting AST nodes."""

--- a/src/asciidoc_parser/nodes.py
+++ b/src/asciidoc_parser/nodes.py
@@ -29,6 +29,10 @@ class Node:
             data['level'] = self.level
         if hasattr(self, 'flavor'):
             data['flavor'] = self.flavor
+        if hasattr(self, 'name'):
+            data['name'] = self.name
+        if hasattr(self, 'value'):
+            data['value'] = self.value
         if hasattr(self, 'title_node') and self.title_node:
             data['title'] = self.title_node.to_dict()
         
@@ -49,7 +53,9 @@ class Node:
             'title': 'title',
             'listitem': 'list_item',
             'literalblock': 'literal_block',
-            'sidebar': 'sidebar'
+            'sidebar': 'sidebar',
+            'exampleblock': 'example_block',
+            'attributeentry': 'attribute_entry'
         }
         data['type'] = type_map.get(data['type'], data['type'])
         
@@ -142,6 +148,10 @@ class LiteralBlock(BlockNode):
         super().__init__()
         self.content = content
         self.attributes = attributes or {}
+
+class ExampleBlock(BlockNode):
+    """Represents an example block."""
+    pass
 
 class QuoteBlock(BlockNode):
     """Represents a block quote."""

--- a/src/asciidoc_parser/preprocessor.py
+++ b/src/asciidoc_parser/preprocessor.py
@@ -1,0 +1,88 @@
+"""
+Preprocessor for AsciiDoc source, handling directives like include::.
+"""
+import os
+import re
+
+class PreprocessorError(Exception):
+    """Custom exception for preprocessor errors."""
+    pass
+
+class Preprocessor:
+    """
+    Processes AsciiDoc source to handle `include::` directives.
+    """
+    def __init__(self, base_dir=None):
+        """
+        Initializes the preprocessor.
+        Args:
+            base_dir (str, optional): The base directory for resolving include paths.
+                                      Defaults to the current working directory.
+        """
+        self.base_dir = os.path.abspath(base_dir) if base_dir else os.getcwd()
+        self.include_regex = re.compile(r'^include::([^\[]+)\[\]\s*$')
+
+    def process(self, source):
+        """
+        Main entry point for processing the source text.
+        Args:
+            source (str): The AsciiDoc source text.
+        Returns:
+            str: The source text with `include::` directives replaced by file content.
+        """
+        return self._process_source(source, self.base_dir, set())
+
+    def _process_source(self, source, current_dir, included_files):
+        """
+        Recursively processes source text, handling includes.
+        Args:
+            source (str): The source text to process.
+            current_dir (str): The directory of the current file being processed,
+                               for resolving relative paths.
+            included_files (set): A set of absolute file paths currently in the
+                                  inclusion chain, to detect circular dependencies.
+        Returns:
+            str: The processed source text.
+        """
+        processed_lines = []
+        for line in source.splitlines(True):
+            match = self.include_regex.match(line.rstrip())
+            if match:
+                include_path = match.group(1).strip()
+
+                target_file_path = os.path.abspath(os.path.join(current_dir, include_path))
+
+                # Security check: ensure the target is within the base directory
+                if os.path.commonprefix([target_file_path, self.base_dir]) != self.base_dir:
+                    raise PreprocessorError(
+                        f"Security error: include path '{include_path}' "
+                        "attempts to access files outside the base directory."
+                    )
+
+                if not os.path.isfile(target_file_path):
+                    raise PreprocessorError(f"Include file not found: {target_file_path}")
+
+                if target_file_path in included_files:
+                    raise PreprocessorError(
+                        f"Circular include detected: '{target_file_path}' "
+                        "is already being included."
+                    )
+
+                with open(target_file_path, 'r', encoding='utf-8') as f:
+                    content_to_include = f.read()
+
+                included_files.add(target_file_path)
+
+                new_current_dir = os.path.dirname(target_file_path)
+
+                processed_content = self._process_source(
+                    content_to_include, new_current_dir, included_files
+                )
+
+                included_files.remove(target_file_path)
+
+                processed_lines.append(processed_content)
+            else:
+                processed_lines.append(line)
+
+        return "".join(processed_lines)

--- a/tests/include_fixtures/circular_a.adoc
+++ b/tests/include_fixtures/circular_a.adoc
@@ -1,0 +1,3 @@
+This is circular A.
+
+include::circular_b.adoc[]

--- a/tests/include_fixtures/circular_b.adoc
+++ b/tests/include_fixtures/circular_b.adoc
@@ -1,0 +1,3 @@
+This is circular B.
+
+include::circular_a.adoc[]

--- a/tests/include_fixtures/main.adoc
+++ b/tests/include_fixtures/main.adoc
@@ -1,0 +1,9 @@
+= Main Document
+
+This document includes another file.
+
+== Included Content
+
+include::paragraph.adoc[]
+
+* A list item in the main file.

--- a/tests/include_fixtures/nested_child.adoc
+++ b/tests/include_fixtures/nested_child.adoc
@@ -1,0 +1,3 @@
+This is the second level.
+
+include::nested_grandchild.adoc[]

--- a/tests/include_fixtures/nested_grandchild.adoc
+++ b/tests/include_fixtures/nested_grandchild.adoc
@@ -1,0 +1,1 @@
+This is the third and final level.

--- a/tests/include_fixtures/nested_main.adoc
+++ b/tests/include_fixtures/nested_main.adoc
@@ -1,0 +1,3 @@
+This file includes another file, which in turn includes a third.
+
+include::nested_child.adoc[]

--- a/tests/include_fixtures/paragraph.adoc
+++ b/tests/include_fixtures/paragraph.adoc
@@ -1,0 +1,1 @@
+This is a paragraph with *bold* and _italic_ text.

--- a/tests/test_document_header.py
+++ b/tests/test_document_header.py
@@ -1,0 +1,94 @@
+
+import pytest
+from asciidoc_parser import parse_to_ast
+
+def test_document_title():
+    source = "= My Document Title\n\n"
+    ast = parse_to_ast(source)
+    assert ast['type'] == 'document'
+    assert 'header' in ast
+    assert ast['header']['type'] == 'header'
+    assert 'title' in ast['header']
+    assert ast['header']['title']['children'][0]['text'] == 'My Document Title'
+    assert 'children' not in ast or not ast['children']
+
+def test_document_title_with_author():
+    source = """= My Document Title
+John Doe
+
+"""
+    ast = parse_to_ast(source)
+    assert ast['type'] == 'document'
+    assert 'header' in ast
+    header = ast['header']
+    assert header['type'] == 'header'
+    assert header['title']['children'][0]['text'] == 'My Document Title'
+    assert 'author' in header
+    assert header['author']['children'][0]['text'] == 'John Doe'
+
+def test_document_title_with_author_and_revision():
+    source = """= My Document Title
+John Doe
+v1.0, 2023-01-01
+
+"""
+    ast = parse_to_ast(source)
+    assert ast['type'] == 'document'
+    assert 'header' in ast
+    header = ast['header']
+    assert header['type'] == 'header'
+    assert header['title']['children'][0]['text'] == 'My Document Title'
+    assert header['author']['children'][0]['text'] == 'John Doe'
+    assert 'revision' in header
+    assert header['revision']['children'][0]['text'] == 'v1.0, 2023-01-01'
+
+def test_header_with_attributes():
+    source = """= My Document Title
+:my-attr: my-value
+:another: another-value
+
+This is a paragraph.
+"""
+    ast = parse_to_ast(source)
+    assert ast['type'] == 'document'
+    assert 'header' in ast
+    header = ast['header']
+    assert header['type'] == 'header'
+
+    attributes = header['attributes']
+    assert attributes['my-attr'][0]['text'] == 'my-value'
+    assert attributes['another'][0]['text'] == 'another-value'
+
+    assert 'children' in ast and len(ast['children']) == 1
+    assert ast['children'][0]['type'] == 'paragraph'
+
+def test_header_only_attributes():
+    source = """:my-attr: my-value
+
+This is a paragraph.
+"""
+    ast = parse_to_ast(source)
+    assert ast['type'] == 'document'
+    assert 'header' not in ast
+    assert ast['children'][0]['type'] == 'attribute_entry'
+    assert ast['children'][1]['type'] == 'paragraph'
+
+def test_no_header():
+    source = "Just a paragraph.\n"
+    ast = parse_to_ast(source)
+    assert ast['type'] == 'document'
+    assert 'header' not in ast
+    assert ast['children'][0]['type'] == 'paragraph'
+
+def test_header_followed_by_section():
+    source = """= My Document Title
+
+== Section 1
+"""
+    ast = parse_to_ast(source)
+    assert ast['type'] == 'document'
+    assert 'header' in ast
+    assert ast['header']['type'] == 'header'
+    assert 'children' in ast and len(ast['children']) == 1
+    assert ast['children'][0]['type'] == 'section'
+    assert ast['children'][0]['title']['children'][0]['text'] == 'Section 1'

--- a/tests/test_document_header.py
+++ b/tests/test_document_header.py
@@ -70,7 +70,7 @@ This is a paragraph.
     ast = parse_to_ast(source).to_dict()
     assert ast['type'] == 'document'
     assert 'header' not in ast
-    assert ast['children'][0]['type'] == 'attributeentry'
+    assert ast['children'][0]['type'] == 'attribute_entry'
     assert ast['children'][1]['type'] == 'paragraph'
 
 def test_no_header():

--- a/tests/test_document_header.py
+++ b/tests/test_document_header.py
@@ -4,7 +4,7 @@ from asciidoc_parser import parse_to_ast
 
 def test_document_title():
     source = "= My Document Title\n\n"
-    ast = parse_to_ast(source)
+    ast = parse_to_ast(source).to_dict()
     assert ast['type'] == 'document'
     assert 'header' in ast
     assert ast['header']['type'] == 'header'
@@ -17,7 +17,7 @@ def test_document_title_with_author():
 John Doe
 
 """
-    ast = parse_to_ast(source)
+    ast = parse_to_ast(source).to_dict()
     assert ast['type'] == 'document'
     assert 'header' in ast
     header = ast['header']
@@ -32,7 +32,7 @@ John Doe
 v1.0, 2023-01-01
 
 """
-    ast = parse_to_ast(source)
+    ast = parse_to_ast(source).to_dict()
     assert ast['type'] == 'document'
     assert 'header' in ast
     header = ast['header']
@@ -49,7 +49,7 @@ def test_header_with_attributes():
 
 This is a paragraph.
 """
-    ast = parse_to_ast(source)
+    ast = parse_to_ast(source).to_dict()
     assert ast['type'] == 'document'
     assert 'header' in ast
     header = ast['header']
@@ -67,7 +67,7 @@ def test_header_only_attributes():
 
 This is a paragraph.
 """
-    ast = parse_to_ast(source)
+    ast = parse_to_ast(source).to_dict()
     assert ast['type'] == 'document'
     assert 'header' not in ast
     assert ast['children'][0]['type'] == 'attribute_entry'
@@ -75,7 +75,7 @@ This is a paragraph.
 
 def test_no_header():
     source = "Just a paragraph.\n"
-    ast = parse_to_ast(source)
+    ast = parse_to_ast(source).to_dict()
     assert ast['type'] == 'document'
     assert 'header' not in ast
     assert ast['children'][0]['type'] == 'paragraph'
@@ -85,7 +85,7 @@ def test_header_followed_by_section():
 
 == Section 1
 """
-    ast = parse_to_ast(source)
+    ast = parse_to_ast(source).to_dict()
     assert ast['type'] == 'document'
     assert 'header' in ast
     assert ast['header']['type'] == 'header'

--- a/tests/test_document_header.py
+++ b/tests/test_document_header.py
@@ -70,7 +70,7 @@ This is a paragraph.
     ast = parse_to_ast(source).to_dict()
     assert ast['type'] == 'document'
     assert 'header' not in ast
-    assert ast['children'][0]['type'] == 'attribute_entry'
+    assert ast['children'][0]['type'] == 'attributeentry'
     assert ast['children'][1]['type'] == 'paragraph'
 
 def test_no_header():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,7 +17,7 @@ def test_example_file_parses(filepath):
         source = f.read()
     
     # We just want to ensure it doesn't raise an exception
-    ast = parse_to_ast(source)
+    ast = parse_to_ast(source).to_dict()
     assert ast is not None
     assert 'type' in ast
     assert ast['type'] == 'document'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -130,6 +130,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(literal['attributes'], {'style': 'source', 'language': 'python'})
         self.assertIn('def foo(): pass', literal['content'])
 
+    def test_section_parsing(self):
         source = "== Section 1\n\nThis is the first section.\n"
         ast = parse_to_ast(source)
         expected_ast = {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,9 +3,23 @@ Tests for the AsciiDoc parser.
 """
 
 import unittest
+import os
+import shutil
 from asciidoc_parser.lark_parser import parse_to_ast
 
 class ParserTest(unittest.TestCase):
+
+    def setUp(self):
+        # Create a temporary directory for test fixtures
+        self.base_dir = os.path.join(os.path.dirname(__file__), 'temp_fixtures')
+        os.makedirs(self.base_dir, exist_ok=True)
+        with open(os.path.join(self.base_dir, 'included.adoc'), 'w') as f:
+            f.write("This is an *included* file.\n\n* With a list item.\n")
+
+    def tearDown(self):
+        # Clean up the temporary directory
+        if os.path.exists(self.base_dir):
+            shutil.rmtree(self.base_dir)
 
     def test_paragraph(self):
         source = "Hello, world.\n"
@@ -461,6 +475,36 @@ class ParserTest(unittest.TestCase):
         title_node = section['title']
         text_node = title_node['children'][0]
         self.assertEqual(text_node['text'], 'Cool Project Docs')
+
+
+    def test_preprocessor_integration(self):
+        source = "include::included.adoc[]"
+        ast = parse_to_ast(source, base_dir=self.base_dir)
+        expected_ast = {
+            'type': 'document',
+            'children': [
+                {
+                    'type': 'paragraph',
+                    'children': [
+                        {'type': 'text', 'text': 'This is an '},
+                        {'type': 'strong', 'children': [{'type': 'text', 'text': 'included'}]},
+                        {'type': 'text', 'text': ' file.'}
+                    ]
+                },
+                {
+                    'type': 'bullet_list',
+                    'children': [
+                        {
+                            'type': 'list_item',
+                            'children': [
+                                {'type': 'text', 'text': 'With a list item.'}
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        self.assertEqual(ast, expected_ast)
 
 
 if __name__ == '__main__':

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -83,7 +83,7 @@ class ParserTest(unittest.TestCase):
                     'type': 'paragraph',
                     'children': [
                         {'type': 'text', 'text': 'This is '},
-                        {'type': 'literal', 'children': [{'type': 'text', 'text': 'monospace'}]},
+                        {'type': 'inlinecode', 'children': [{'type': 'text', 'text': 'monospace'}]},
                         {'type': 'text', 'text': ' text.'}
                     ]
                 }
@@ -98,11 +98,11 @@ class ParserTest(unittest.TestCase):
             'type': 'document',
             'children': [
                 {
-                    'type': 'bullet_list',
+                    'type': 'bulletlist',
                     'children': [
-                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'one'}]},
-                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'two'}]},
-                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'three'}]}
+                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'one'}]},
+                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'two'}]},
+                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'three'}]}
                     ]
                 }
             ]
@@ -116,11 +116,11 @@ class ParserTest(unittest.TestCase):
             'type': 'document',
             'children': [
                 {
-                    'type': 'enumerated_list',
+                    'type': 'orderedlist',
                     'children': [
-                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'one'}]},
-                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'two'}]},
-                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'three'}]}
+                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'one'}]},
+                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'two'}]},
+                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'three'}]}
                     ]
                 }
             ]
@@ -131,7 +131,7 @@ class ParserTest(unittest.TestCase):
         source = "----\nThis is a literal block.\n----\n"
         ast = parse_to_ast(source).to_dict()
         literal = ast['children'][0]
-        self.assertEqual(literal['type'], 'literal_block')
+        self.assertEqual(literal['type'], 'literalblock')
         # Content regex might capture newlines
         self.assertIn('This is a literal block.', literal['content'])
         self.assertEqual(literal.get('attributes', {}), {})
@@ -140,7 +140,7 @@ class ParserTest(unittest.TestCase):
         source = "[source,python]\n----\ndef foo(): pass\n----\n"
         ast = parse_to_ast(source).to_dict()
         literal = ast['children'][0]
-        self.assertEqual(literal['type'], 'literal_block')
+        self.assertEqual(literal['type'], 'literalblock')
         self.assertEqual(literal['attributes'], {'style': 'source', 'language': 'python'})
         self.assertIn('def foo(): pass', literal['content'])
 
@@ -189,14 +189,14 @@ class ParserTest(unittest.TestCase):
         ast = parse_to_ast(source).to_dict()
         # Verify structure via dict conversion
         self.assertEqual(ast['type'], 'document')
-        self.assertEqual(ast['children'][0]['type'], 'bullet_list')
+        self.assertEqual(ast['children'][0]['type'], 'bulletlist')
 
     def test_list_item_with_formatting(self):
         source = "* basic item\n* item with *bold* and _italic_\n"
         ast = parse_to_ast(source).to_dict()
         # Verify that the second item has children including bold and italic
         second_item = ast['children'][0]['children'][1]
-        self.assertEqual(second_item['type'], 'list_item')
+        self.assertEqual(second_item['type'], 'listitem')
         content_nodes = second_item['children']
         
         # Types: 'item with ', 'strong', ' and ', 'emphasis'
@@ -259,7 +259,7 @@ class ParserTest(unittest.TestCase):
         # Should have paragraph and bullet list (may have blank lines between)
         child_types = [c['type'] for c in admonition['children']]
         self.assertIn('paragraph', child_types)
-        self.assertIn('bullet_list', child_types)
+        self.assertIn('bulletlist', child_types)
 
     def test_admonition_with_formatting(self):
         source = "[TIP]\n====\nUse *bold* and _italic_ formatting.\n====\n"
@@ -295,7 +295,7 @@ class ParserTest(unittest.TestCase):
         admonition = ast['children'][0]
         child_types = [c['type'] for c in admonition['children']]
         self.assertIn('paragraph', child_types)
-        self.assertIn('literal_block', child_types)
+        self.assertIn('literalblock', child_types)
 
     def test_admonition_whitespace_in_label(self):
         source = "[  NOTE  ]\n====\nContent with whitespace in label.\n====\n"
@@ -336,8 +336,8 @@ class ParserTest(unittest.TestCase):
         sidebar = ast['children'][0]
         child_types = [c['type'] for c in sidebar['children']]
         self.assertIn('paragraph', child_types)
-        self.assertIn('bullet_list', child_types)
-        self.assertIn('literal_block', child_types)
+        self.assertIn('bulletlist', child_types)
+        self.assertIn('literalblock', child_types)
 
     def test_sidebar_empty(self):
         source = "****\n****\n"
@@ -374,7 +374,7 @@ class ParserTest(unittest.TestCase):
         source = "====\nThis is an example block.\n====\n"
         ast = parse_to_ast(source).to_dict()
         example = ast['children'][0]
-        self.assertEqual(example['type'], 'example_block')
+        self.assertEqual(example['type'], 'exampleblock')
         self.assertEqual(len(example['children']), 1)
         self.assertEqual(example['children'][0]['type'], 'paragraph')
 
@@ -382,7 +382,7 @@ class ParserTest(unittest.TestCase):
         source = "====\n****\nSidebar in example\n****\n====\n"
         ast = parse_to_ast(source).to_dict()
         example = ast['children'][0]
-        self.assertEqual(example['type'], 'example_block')
+        self.assertEqual(example['type'], 'exampleblock')
         sidebar = example['children'][0]
         self.assertEqual(sidebar['type'], 'sidebar')
 
@@ -395,13 +395,13 @@ class ParserTest(unittest.TestCase):
         # ==== alone -> Example
         source_ex = "====\nExample content\n====\n"
         ast_ex = parse_to_ast(source_ex).to_dict()
-        self.assertEqual(ast_ex['children'][0]['type'], 'example_block')
+        self.assertEqual(ast_ex['children'][0]['type'], 'exampleblock')
 
     def test_attribute_entry(self):
         source = ":author: Michael Bernstein\n"
         ast = parse_to_ast(source).to_dict()
         attr = ast['children'][0]
-        self.assertEqual(attr['type'], 'attribute_entry')
+        self.assertEqual(attr['type'], 'attributeentry')
         self.assertEqual(attr['name'], 'author')
         self.assertEqual(attr['value'], 'Michael Bernstein')
 
@@ -409,7 +409,7 @@ class ParserTest(unittest.TestCase):
         source = ":myattr:\n"
         ast = parse_to_ast(source).to_dict()
         attr = ast['children'][0]
-        self.assertEqual(attr['type'], 'attribute_entry')
+        self.assertEqual(attr['type'], 'attributeentry')
         self.assertEqual(attr['name'], 'myattr')
         self.assertEqual(attr['value'], '')
 
@@ -492,10 +492,10 @@ class ParserTest(unittest.TestCase):
                     ]
                 },
                 {
-                    'type': 'bullet_list',
+                    'type': 'bulletlist',
                     'children': [
                         {
-                            'type': 'list_item',
+                            'type': 'listitem',
                             'children': [
                                 {'type': 'text', 'text': 'With a list item.'}
                             ]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -355,5 +355,82 @@ class ParserTest(unittest.TestCase):
         sidebar = admonition['children'][0]
         self.assertEqual(sidebar['type'], 'sidebar')
 
+    def test_example_block_basic(self):
+        source = "====\nThis is an example block.\n====\n"
+        ast = parse_to_ast(source)
+        example = ast['children'][0]
+        self.assertEqual(example['type'], 'example_block')
+        self.assertEqual(len(example['children']), 1)
+        self.assertEqual(example['children'][0]['type'], 'paragraph')
+
+    def test_example_block_nesting(self):
+        source = "====\n****\nSidebar in example\n****\n====\n"
+        ast = parse_to_ast(source)
+        example = ast['children'][0]
+        self.assertEqual(example['type'], 'example_block')
+        sidebar = example['children'][0]
+        self.assertEqual(sidebar['type'], 'sidebar')
+
+    def test_admonition_vs_example(self):
+        # NOTE + ==== -> Admonition
+        source_adm = "[NOTE]\n====\nNote content\n====\n"
+        ast_adm = parse_to_ast(source_adm)
+        self.assertEqual(ast_adm['children'][0]['type'], 'admonition')
+        
+        # ==== alone -> Example
+        source_ex = "====\nExample content\n====\n"
+        ast_ex = parse_to_ast(source_ex)
+        self.assertEqual(ast_ex['children'][0]['type'], 'example_block')
+
+    def test_attribute_entry(self):
+        source = ":author: Michael Bernstein\n"
+        ast = parse_to_ast(source)
+        attr = ast['children'][0]
+        self.assertEqual(attr['type'], 'attribute_entry')
+        self.assertEqual(attr['name'], 'author')
+        self.assertEqual(attr['value'], 'Michael Bernstein')
+
+    def test_attribute_entry_empty(self):
+        source = ":myattr:\n"
+        ast = parse_to_ast(source)
+        attr = ast['children'][0]
+        self.assertEqual(attr['type'], 'attribute_entry')
+        self.assertEqual(attr['name'], 'myattr')
+        self.assertEqual(attr['value'], '')
+
+    def test_attribute_substitution(self):
+        source = ":author: Michael\nHello {author}!\n"
+        ast = parse_to_ast(source)
+        # children: [AttributeEntry, Paragraph]
+        paragraph = ast['children'][1]
+        self.assertEqual(paragraph['type'], 'paragraph')
+        text_node = paragraph['children'][0]
+        self.assertEqual(text_node['text'], 'Hello Michael!')
+
+    def test_attribute_substitution_not_found(self):
+        source = "Hello {unknown}!\n"
+        ast = parse_to_ast(source)
+        paragraph = ast['children'][0]
+        text_node = paragraph['children'][0]
+        self.assertEqual(text_node['text'], 'Hello {unknown}!')
+
+    def test_attribute_substitution_in_title(self):
+        source = ":project: AsciiDocParser\n== {project} Documentation\n"
+        ast = parse_to_ast(source)
+        # children: [AttributeEntry, Section]
+        section = ast['children'][1]
+        self.assertEqual(section['type'], 'section')
+        title_node = section['title']
+        text_node = title_node['children'][0]
+        self.assertEqual(text_node['text'], 'AsciiDocParser Documentation')
+
+    def test_attribute_substitution_nested(self):
+        source = ":project: AsciiDoc\n:tool: {project}Parser\nThis is {tool}.\n"
+        ast = parse_to_ast(source)
+        # children: [Attr, Attr, Paragraph]
+        paragraph = ast['children'][2]
+        text_node = paragraph['children'][0]
+        self.assertEqual(text_node['text'], 'This is AsciiDocParser.')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,7 +23,7 @@ class ParserTest(unittest.TestCase):
 
     def test_paragraph(self):
         source = "Hello, world.\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         expected_ast = {
             'type': 'document',
             'children': [
@@ -39,7 +39,7 @@ class ParserTest(unittest.TestCase):
 
     def test_bold(self):
         source = "This is *bold* text.\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         expected_ast = {
             'type': 'document',
             'children': [
@@ -57,7 +57,7 @@ class ParserTest(unittest.TestCase):
 
     def test_italic(self):
         source = "This is _italic_ text.\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         expected_ast = {
             'type': 'document',
             'children': [
@@ -75,7 +75,7 @@ class ParserTest(unittest.TestCase):
 
     def test_monospace(self):
         source = "This is `monospace` text.\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         expected_ast = {
             'type': 'document',
             'children': [
@@ -93,7 +93,7 @@ class ParserTest(unittest.TestCase):
 
     def test_ulist(self):
         source = "* one\n* two\n* three\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         expected_ast = {
             'type': 'document',
             'children': [
@@ -111,7 +111,7 @@ class ParserTest(unittest.TestCase):
 
     def test_olist(self):
         source = "1. one\n2. two\n3. three\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         expected_ast = {
             'type': 'document',
             'children': [
@@ -129,7 +129,7 @@ class ParserTest(unittest.TestCase):
 
     def test_literal_block(self):
         source = "----\nThis is a literal block.\n----\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         literal = ast['children'][0]
         self.assertEqual(literal['type'], 'literal_block')
         # Content regex might capture newlines
@@ -138,7 +138,7 @@ class ParserTest(unittest.TestCase):
 
     def test_source_block_attributes(self):
         source = "[source,python]\n----\ndef foo(): pass\n----\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         literal = ast['children'][0]
         self.assertEqual(literal['type'], 'literal_block')
         self.assertEqual(literal['attributes'], {'style': 'source', 'language': 'python'})
@@ -146,7 +146,7 @@ class ParserTest(unittest.TestCase):
 
     def test_section_parsing(self):
         source = "== Section 1\n\nThis is the first section.\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         expected_ast = {
             'type': 'document',
             'children': [
@@ -170,7 +170,7 @@ class ParserTest(unittest.TestCase):
     def test_symbols_in_word(self):
         # Ensure that characters like commas, periods, etc. don't break WORD
         source = "Hello, world! (tested)\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         expected_ast = {
             'type': 'document',
             'children': [
@@ -186,14 +186,14 @@ class ParserTest(unittest.TestCase):
 
     def test_nested_lists(self):
         source = "* level 1\n** level 2\n* back to 1\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         # Verify structure via dict conversion
         self.assertEqual(ast['type'], 'document')
         self.assertEqual(ast['children'][0]['type'], 'bullet_list')
 
     def test_list_item_with_formatting(self):
         source = "* basic item\n* item with *bold* and _italic_\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         # Verify that the second item has children including bold and italic
         second_item = ast['children'][0]['children'][1]
         self.assertEqual(second_item['type'], 'list_item')
@@ -206,7 +206,7 @@ class ParserTest(unittest.TestCase):
 
     def test_admonition_note(self):
         source = "[NOTE]\n====\nThis is a note.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         expected_ast = {
             'type': 'document',
             'children': [
@@ -228,31 +228,31 @@ class ParserTest(unittest.TestCase):
 
     def test_admonition_tip(self):
         source = "[TIP]\n====\nHere's a helpful tip.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         self.assertEqual(ast['children'][0]['type'], 'admonition')
         self.assertEqual(ast['children'][0]['flavor'], 'tip')
 
     def test_admonition_important(self):
         source = "[IMPORTANT]\n====\nPay attention to this.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         self.assertEqual(ast['children'][0]['type'], 'admonition')
         self.assertEqual(ast['children'][0]['flavor'], 'important')
 
     def test_admonition_warning(self):
         source = "[WARNING]\n====\nBe careful here.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         self.assertEqual(ast['children'][0]['type'], 'admonition')
         self.assertEqual(ast['children'][0]['flavor'], 'warning')
 
     def test_admonition_caution(self):
         source = "[CAUTION]\n====\nProceed with caution.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         self.assertEqual(ast['children'][0]['type'], 'admonition')
         self.assertEqual(ast['children'][0]['flavor'], 'caution')
 
     def test_admonition_with_list(self):
         source = "[NOTE]\n====\nConsider these points:\n\n- First point\n- Second point\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         admonition = ast['children'][0]
         self.assertEqual(admonition['type'], 'admonition')
         self.assertEqual(admonition['flavor'], 'note')
@@ -263,7 +263,7 @@ class ParserTest(unittest.TestCase):
 
     def test_admonition_with_formatting(self):
         source = "[TIP]\n====\nUse *bold* and _italic_ formatting.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         admonition = ast['children'][0]
         paragraph = admonition['children'][0]
         # Check that formatting is preserved
@@ -273,7 +273,7 @@ class ParserTest(unittest.TestCase):
 
     def test_admonition_empty(self):
         source = "[NOTE]\n====\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         admonition = ast['children'][0]
         self.assertEqual(admonition['type'], 'admonition')
         self.assertEqual(admonition['flavor'], 'note')
@@ -284,14 +284,14 @@ class ParserTest(unittest.TestCase):
 
     def test_admonition_multiple_paragraphs(self):
         source = "[NOTE]\n====\nFirst paragraph.\n\nSecond paragraph.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         admonition = ast['children'][0]
         paragraphs = [c for c in admonition['children'] if c['type'] == 'paragraph']
         self.assertGreaterEqual(len(paragraphs), 2)
 
     def test_admonition_with_literal_block(self):
         source = "[TIP]\n====\nHere's some code:\n\n----\ndef hello():\n    print(\"world\")\n----\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         admonition = ast['children'][0]
         child_types = [c['type'] for c in admonition['children']]
         self.assertIn('paragraph', child_types)
@@ -299,14 +299,14 @@ class ParserTest(unittest.TestCase):
 
     def test_admonition_whitespace_in_label(self):
         source = "[  NOTE  ]\n====\nContent with whitespace in label.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         admonition = ast['children'][0]
         self.assertEqual(admonition['type'], 'admonition')
         self.assertEqual(admonition['flavor'], 'note')
 
     def test_multiple_admonitions(self):
         source = "[NOTE]\n====\nFirst note.\n====\n\n[WARNING]\n====\nA warning.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         admonitions = [c for c in ast['children'] if c['type'] == 'admonition']
         self.assertEqual(len(admonitions), 2)
         self.assertEqual(admonitions[0]['flavor'], 'note')
@@ -314,7 +314,7 @@ class ParserTest(unittest.TestCase):
 
     def test_admonition_in_section(self):
         source = "== Section Title\n\n[NOTE]\n====\nNote in a section.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         section = ast['children'][0]
         self.assertEqual(section['type'], 'section')
         admonitions = [c for c in section['children'] if c['type'] == 'admonition']
@@ -323,7 +323,7 @@ class ParserTest(unittest.TestCase):
 
     def test_sidebar_basic(self):
         source = "****\nThis is a sidebar.\n****\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         sidebar = ast['children'][0]
         self.assertEqual(sidebar['type'], 'sidebar')
         self.assertEqual(len(sidebar['children']), 1)
@@ -332,7 +332,7 @@ class ParserTest(unittest.TestCase):
 
     def test_sidebar_nested_content(self):
         source = "****\nSidebar paragraph.\n\n- List item\n\n----\ncode\n----\n****\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         sidebar = ast['children'][0]
         child_types = [c['type'] for c in sidebar['children']]
         self.assertIn('paragraph', child_types)
@@ -341,7 +341,7 @@ class ParserTest(unittest.TestCase):
 
     def test_sidebar_empty(self):
         source = "****\n****\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         sidebar = ast['children'][0]
         # Should be empty or have blank lines, handle missing 'children' key safely
         children = sidebar.get('children', [])
@@ -349,13 +349,13 @@ class ParserTest(unittest.TestCase):
 
     def test_sidebar_multiple(self):
         source = "****\nContent 1\n****\n\n****\nContent 2\n****\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         sidebars = [c for c in ast['children'] if c['type'] == 'sidebar']
         self.assertEqual(len(sidebars), 2)
 
     def test_sidebar_nested_admonition(self):
         source = "****\n[NOTE]\n====\nNote inside sidebar\n====\n****\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         sidebar = ast['children'][0]
         self.assertEqual(sidebar['type'], 'sidebar')
         admonition = sidebar['children'][0]
@@ -364,7 +364,7 @@ class ParserTest(unittest.TestCase):
 
     def test_admonition_nested_sidebar(self):
         source = "[TIP]\n====\n****\nSidebar inside tip\n****\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         admonition = ast['children'][0]
         self.assertEqual(admonition['type'], 'admonition')
         sidebar = admonition['children'][0]
@@ -372,7 +372,7 @@ class ParserTest(unittest.TestCase):
 
     def test_example_block_basic(self):
         source = "====\nThis is an example block.\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         example = ast['children'][0]
         self.assertEqual(example['type'], 'example_block')
         self.assertEqual(len(example['children']), 1)
@@ -380,7 +380,7 @@ class ParserTest(unittest.TestCase):
 
     def test_example_block_nesting(self):
         source = "====\n****\nSidebar in example\n****\n====\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         example = ast['children'][0]
         self.assertEqual(example['type'], 'example_block')
         sidebar = example['children'][0]
@@ -389,17 +389,17 @@ class ParserTest(unittest.TestCase):
     def test_admonition_vs_example(self):
         # NOTE + ==== -> Admonition
         source_adm = "[NOTE]\n====\nNote content\n====\n"
-        ast_adm = parse_to_ast(source_adm)
+        ast_adm = parse_to_ast(source_adm).to_dict()
         self.assertEqual(ast_adm['children'][0]['type'], 'admonition')
         
         # ==== alone -> Example
         source_ex = "====\nExample content\n====\n"
-        ast_ex = parse_to_ast(source_ex)
+        ast_ex = parse_to_ast(source_ex).to_dict()
         self.assertEqual(ast_ex['children'][0]['type'], 'example_block')
 
     def test_attribute_entry(self):
         source = ":author: Michael Bernstein\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         attr = ast['children'][0]
         self.assertEqual(attr['type'], 'attribute_entry')
         self.assertEqual(attr['name'], 'author')
@@ -407,7 +407,7 @@ class ParserTest(unittest.TestCase):
 
     def test_attribute_entry_empty(self):
         source = ":myattr:\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         attr = ast['children'][0]
         self.assertEqual(attr['type'], 'attribute_entry')
         self.assertEqual(attr['name'], 'myattr')
@@ -415,7 +415,7 @@ class ParserTest(unittest.TestCase):
 
     def test_attribute_substitution(self):
         source = ":author: Michael\nHello {author}!\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         # children: [AttributeEntry, Paragraph]
         paragraph = ast['children'][1]
         self.assertEqual(paragraph['type'], 'paragraph')
@@ -424,14 +424,14 @@ class ParserTest(unittest.TestCase):
 
     def test_attribute_substitution_not_found(self):
         source = "Hello {unknown}!\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         paragraph = ast['children'][0]
         text_node = paragraph['children'][0]
         self.assertEqual(text_node['text'], 'Hello {unknown}!')
 
     def test_attribute_substitution_in_title(self):
         source = ":project: AsciiDocParser\n== {project} Documentation\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         # children: [AttributeEntry, Section]
         section = ast['children'][1]
         self.assertEqual(section['type'], 'section')
@@ -441,7 +441,7 @@ class ParserTest(unittest.TestCase):
 
     def test_attribute_substitution_nested(self):
         source = ":project: AsciiDoc\n:tool: {project}Parser\nThis is {tool}.\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         # children: [Attr, Attr, Paragraph]
         paragraph = ast['children'][2]
         text_node = paragraph['children'][0]
@@ -449,7 +449,7 @@ class ParserTest(unittest.TestCase):
 
     def test_attribute_with_inline_formatting(self):
         source = ":author: *Jane* _Smith_\nHello {author}!\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         paragraph = ast['children'][1]
         self.assertEqual(paragraph['type'], 'paragraph')
         # Expected: Hello *Jane* _Smith_! -> Text, Strong, Text, Emphasis, Text
@@ -464,13 +464,13 @@ class ParserTest(unittest.TestCase):
 
     def test_deeply_nested_attribute_substitution(self):
         source = ":a: 1\n:b: {a}{a}\n:c: {b}{b}\nResult is {c}.\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         paragraph = ast['children'][3]
         self.assertEqual(paragraph['children'][0]['text'], 'Result is 1111.')
 
     def test_recursive_attribute_substitution(self):
         source = ":project_name: Cool Project\n:doc_title: {project_name} Docs\n== {doc_title}\n"
-        ast = parse_to_ast(source)
+        ast = parse_to_ast(source).to_dict()
         section = ast['children'][2]
         title_node = section['title']
         text_node = title_node['children'][0]
@@ -479,7 +479,7 @@ class ParserTest(unittest.TestCase):
 
     def test_preprocessor_integration(self):
         source = "include::included.adoc[]"
-        ast = parse_to_ast(source, base_dir=self.base_dir)
+        ast = parse_to_ast(source, base_dir=self.base_dir).to_dict()
         expected_ast = {
             'type': 'document',
             'children': [

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -433,5 +433,35 @@ class ParserTest(unittest.TestCase):
         text_node = paragraph['children'][0]
         self.assertEqual(text_node['text'], 'This is AsciiDocParser.')
 
+    def test_attribute_with_inline_formatting(self):
+        source = ":author: *Jane* _Smith_\nHello {author}!\n"
+        ast = parse_to_ast(source)
+        paragraph = ast['children'][1]
+        self.assertEqual(paragraph['type'], 'paragraph')
+        # Expected: Hello *Jane* _Smith_! -> Text, Strong, Text, Emphasis, Text
+        self.assertEqual(len(paragraph['children']), 5)
+        self.assertEqual(paragraph['children'][0]['text'], 'Hello ')
+        self.assertEqual(paragraph['children'][1]['type'], 'strong')
+        self.assertEqual(paragraph['children'][1]['children'][0]['text'], 'Jane')
+        self.assertEqual(paragraph['children'][2]['text'], ' ')
+        self.assertEqual(paragraph['children'][3]['type'], 'emphasis')
+        self.assertEqual(paragraph['children'][3]['children'][0]['text'], 'Smith')
+        self.assertEqual(paragraph['children'][4]['text'], '!')
+
+    def test_deeply_nested_attribute_substitution(self):
+        source = ":a: 1\n:b: {a}{a}\n:c: {b}{b}\nResult is {c}.\n"
+        ast = parse_to_ast(source)
+        paragraph = ast['children'][3]
+        self.assertEqual(paragraph['children'][0]['text'], 'Result is 1111.')
+
+    def test_recursive_attribute_substitution(self):
+        source = ":project_name: Cool Project\n:doc_title: {project_name} Docs\n== {doc_title}\n"
+        ast = parse_to_ast(source)
+        section = ast['children'][2]
+        title_node = section['title']
+        text_node = title_node['children'][0]
+        self.assertEqual(text_node['text'], 'Cool Project Docs')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -83,7 +83,7 @@ class ParserTest(unittest.TestCase):
                     'type': 'paragraph',
                     'children': [
                         {'type': 'text', 'text': 'This is '},
-                        {'type': 'inlinecode', 'children': [{'type': 'text', 'text': 'monospace'}]},
+                        {'type': 'literal', 'children': [{'type': 'text', 'text': 'monospace'}]},
                         {'type': 'text', 'text': ' text.'}
                     ]
                 }
@@ -98,11 +98,11 @@ class ParserTest(unittest.TestCase):
             'type': 'document',
             'children': [
                 {
-                    'type': 'bulletlist',
+                    'type': 'bullet_list',
                     'children': [
-                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'one'}]},
-                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'two'}]},
-                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'three'}]}
+                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'one'}]},
+                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'two'}]},
+                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'three'}]}
                     ]
                 }
             ]
@@ -116,11 +116,11 @@ class ParserTest(unittest.TestCase):
             'type': 'document',
             'children': [
                 {
-                    'type': 'orderedlist',
+                    'type': 'enumerated_list',
                     'children': [
-                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'one'}]},
-                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'two'}]},
-                        {'type': 'listitem', 'children': [{'type': 'text', 'text': 'three'}]}
+                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'one'}]},
+                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'two'}]},
+                        {'type': 'list_item', 'children': [{'type': 'text', 'text': 'three'}]}
                     ]
                 }
             ]
@@ -131,7 +131,7 @@ class ParserTest(unittest.TestCase):
         source = "----\nThis is a literal block.\n----\n"
         ast = parse_to_ast(source).to_dict()
         literal = ast['children'][0]
-        self.assertEqual(literal['type'], 'literalblock')
+        self.assertEqual(literal['type'], 'literal_block')
         # Content regex might capture newlines
         self.assertIn('This is a literal block.', literal['content'])
         self.assertEqual(literal.get('attributes', {}), {})
@@ -140,7 +140,7 @@ class ParserTest(unittest.TestCase):
         source = "[source,python]\n----\ndef foo(): pass\n----\n"
         ast = parse_to_ast(source).to_dict()
         literal = ast['children'][0]
-        self.assertEqual(literal['type'], 'literalblock')
+        self.assertEqual(literal['type'], 'literal_block')
         self.assertEqual(literal['attributes'], {'style': 'source', 'language': 'python'})
         self.assertIn('def foo(): pass', literal['content'])
 
@@ -189,14 +189,14 @@ class ParserTest(unittest.TestCase):
         ast = parse_to_ast(source).to_dict()
         # Verify structure via dict conversion
         self.assertEqual(ast['type'], 'document')
-        self.assertEqual(ast['children'][0]['type'], 'bulletlist')
+        self.assertEqual(ast['children'][0]['type'], 'bullet_list')
 
     def test_list_item_with_formatting(self):
         source = "* basic item\n* item with *bold* and _italic_\n"
         ast = parse_to_ast(source).to_dict()
         # Verify that the second item has children including bold and italic
         second_item = ast['children'][0]['children'][1]
-        self.assertEqual(second_item['type'], 'listitem')
+        self.assertEqual(second_item['type'], 'list_item')
         content_nodes = second_item['children']
         
         # Types: 'item with ', 'strong', ' and ', 'emphasis'
@@ -259,7 +259,7 @@ class ParserTest(unittest.TestCase):
         # Should have paragraph and bullet list (may have blank lines between)
         child_types = [c['type'] for c in admonition['children']]
         self.assertIn('paragraph', child_types)
-        self.assertIn('bulletlist', child_types)
+        self.assertIn('bullet_list', child_types)
 
     def test_admonition_with_formatting(self):
         source = "[TIP]\n====\nUse *bold* and _italic_ formatting.\n====\n"
@@ -295,7 +295,7 @@ class ParserTest(unittest.TestCase):
         admonition = ast['children'][0]
         child_types = [c['type'] for c in admonition['children']]
         self.assertIn('paragraph', child_types)
-        self.assertIn('literalblock', child_types)
+        self.assertIn('literal_block', child_types)
 
     def test_admonition_whitespace_in_label(self):
         source = "[  NOTE  ]\n====\nContent with whitespace in label.\n====\n"
@@ -336,8 +336,8 @@ class ParserTest(unittest.TestCase):
         sidebar = ast['children'][0]
         child_types = [c['type'] for c in sidebar['children']]
         self.assertIn('paragraph', child_types)
-        self.assertIn('bulletlist', child_types)
-        self.assertIn('literalblock', child_types)
+        self.assertIn('bullet_list', child_types)
+        self.assertIn('literal_block', child_types)
 
     def test_sidebar_empty(self):
         source = "****\n****\n"
@@ -374,7 +374,7 @@ class ParserTest(unittest.TestCase):
         source = "====\nThis is an example block.\n====\n"
         ast = parse_to_ast(source).to_dict()
         example = ast['children'][0]
-        self.assertEqual(example['type'], 'exampleblock')
+        self.assertEqual(example['type'], 'example_block')
         self.assertEqual(len(example['children']), 1)
         self.assertEqual(example['children'][0]['type'], 'paragraph')
 
@@ -382,7 +382,7 @@ class ParserTest(unittest.TestCase):
         source = "====\n****\nSidebar in example\n****\n====\n"
         ast = parse_to_ast(source).to_dict()
         example = ast['children'][0]
-        self.assertEqual(example['type'], 'exampleblock')
+        self.assertEqual(example['type'], 'example_block')
         sidebar = example['children'][0]
         self.assertEqual(sidebar['type'], 'sidebar')
 
@@ -395,13 +395,13 @@ class ParserTest(unittest.TestCase):
         # ==== alone -> Example
         source_ex = "====\nExample content\n====\n"
         ast_ex = parse_to_ast(source_ex).to_dict()
-        self.assertEqual(ast_ex['children'][0]['type'], 'exampleblock')
+        self.assertEqual(ast_ex['children'][0]['type'], 'example_block')
 
     def test_attribute_entry(self):
         source = ":author: Michael Bernstein\n"
         ast = parse_to_ast(source).to_dict()
         attr = ast['children'][0]
-        self.assertEqual(attr['type'], 'attributeentry')
+        self.assertEqual(attr['type'], 'attribute_entry')
         self.assertEqual(attr['name'], 'author')
         self.assertEqual(attr['value'], 'Michael Bernstein')
 
@@ -409,7 +409,7 @@ class ParserTest(unittest.TestCase):
         source = ":myattr:\n"
         ast = parse_to_ast(source).to_dict()
         attr = ast['children'][0]
-        self.assertEqual(attr['type'], 'attributeentry')
+        self.assertEqual(attr['type'], 'attribute_entry')
         self.assertEqual(attr['name'], 'myattr')
         self.assertEqual(attr['value'], '')
 
@@ -492,10 +492,10 @@ class ParserTest(unittest.TestCase):
                     ]
                 },
                 {
-                    'type': 'bulletlist',
+                    'type': 'bullet_list',
                     'children': [
                         {
-                            'type': 'listitem',
+                            'type': 'list_item',
                             'children': [
                                 {'type': 'text', 'text': 'With a list item.'}
                             ]

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -1,0 +1,86 @@
+"""
+Tests for the AsciiDoc preprocessor.
+"""
+import unittest
+import os
+import shutil
+from asciidoc_parser.preprocessor import Preprocessor, PreprocessorError
+
+class PreprocessorTest(unittest.TestCase):
+
+    def setUp(self):
+        # Create a temporary directory for test fixtures
+        self.base_dir = os.path.join(os.path.dirname(__file__), 'temp_fixtures')
+        os.makedirs(self.base_dir, exist_ok=True)
+
+        # Create some sample files
+        with open(os.path.join(self.base_dir, 'main.adoc'), 'w') as f:
+            f.write("= Main Document\n\ninclude::paragraph.adoc[]")
+        with open(os.path.join(self.base_dir, 'paragraph.adoc'), 'w') as f:
+            f.write("This is an included paragraph.")
+
+        # For nested includes
+        with open(os.path.join(self.base_dir, 'nested_main.adoc'), 'w') as f:
+            f.write("Level 1\ninclude::nested_child.adoc[]")
+        with open(os.path.join(self.base_dir, 'nested_child.adoc'), 'w') as f:
+            f.write("Level 2\ninclude::nested_grandchild.adoc[]")
+        with open(os.path.join(self.base_dir, 'nested_grandchild.adoc'), 'w') as f:
+            f.write("Level 3")
+
+        # For circular includes
+        with open(os.path.join(self.base_dir, 'circular_a.adoc'), 'w') as f:
+            f.write("Circular A\ninclude::circular_b.adoc[]")
+        with open(os.path.join(self.base_dir, 'circular_b.adoc'), 'w') as f:
+            f.write("Circular B\ninclude::circular_a.adoc[]")
+
+        # For security tests
+        self.outside_dir = os.path.join(os.path.dirname(__file__), 'outside_fixtures')
+        os.makedirs(self.outside_dir, exist_ok=True)
+        with open(os.path.join(self.outside_dir, 'secret.adoc'), 'w') as f:
+            f.write("This is a secret file.")
+
+    def tearDown(self):
+        # Clean up the temporary directories
+        if os.path.exists(self.base_dir):
+            shutil.rmtree(self.base_dir)
+        if os.path.exists(self.outside_dir):
+            shutil.rmtree(self.outside_dir)
+
+    def test_basic_include(self):
+        preprocessor = Preprocessor(base_dir=self.base_dir)
+        source = "include::main.adoc[]"
+        processed = preprocessor.process(source)
+        expected = "= Main Document\n\nThis is an included paragraph."
+        self.assertEqual(processed.strip(), expected.strip())
+
+    def test_nested_include(self):
+        preprocessor = Preprocessor(base_dir=self.base_dir)
+        source = "include::nested_main.adoc[]"
+        processed = preprocessor.process(source)
+        expected = "Level 1\nLevel 2\nLevel 3"
+        self.assertEqual(processed.strip(), expected.strip())
+
+    def test_file_not_found(self):
+        preprocessor = Preprocessor(base_dir=self.base_dir)
+        source = "include::nonexistent.adoc[]"
+        with self.assertRaises(PreprocessorError) as context:
+            preprocessor.process(source)
+        self.assertIn("Include file not found", str(context.exception))
+
+    def test_circular_include(self):
+        preprocessor = Preprocessor(base_dir=self.base_dir)
+        source = "include::circular_a.adoc[]"
+        with self.assertRaises(PreprocessorError) as context:
+            preprocessor.process(source)
+        self.assertIn("Circular include detected", str(context.exception))
+
+    def test_security_path_traversal(self):
+        preprocessor = Preprocessor(base_dir=self.base_dir)
+        # Attempt to access a file outside the base_dir
+        source = "include::../outside_fixtures/secret.adoc[]"
+        with self.assertRaises(PreprocessorError) as context:
+            preprocessor.process(source)
+        self.assertIn("attempts to access files outside the base directory", str(context.exception))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Phase 2: Document Infrastructure and Attributes

- **Document Header & Attributes**
  - [x] Implement attribute entry parsing (`:name: value`)
  - [x] Create `AttributeEntry` node and registry in `AsciiDocTransformer`
  - [x] Support attribute substitution in paragraphs and titles (`{name}`)
- **Includes & Preprocessing**
  - [x] Implement `include::` directive grammar
  - [x] Build a basic Preprocessor to resolve includes before main parsing
  - [x] Add security/safe-mode checks for file path resolution
- **Advanced Title Handling**
  - [x] Support for document title (`= Title`) vs section titles
  - [x] Attribute propagation from header to document state
 - **Refactoring and Types**
   - [x] Decoupled parsing logic from test serialization
   - [x] Added type hints and `NodeType` enum to strengthen AST
   - [x] Improved attribute representation and handling 