### PR TITLE
Implement TCK Adapter (Task #36)

### DIFF
--- a/bin/tck-adapter.py
+++ b/bin/tck-adapter.py
@@ -1,26 +1,40 @@
 #!/usr/bin/env python3
 import sys
 import json
+from asciidoc_parser import parse_to_ast
 
 def main():
     try:
-        # Read from stdin
+        # Read from stdin (TASK-2.1 / Issue #37)
         input_data = sys.stdin.read()
         if not input_data:
             return
 
         payload = json.loads(input_data)
-        # For now, we don't do anything with the payload
-        # but we successfully parsed it.
+        contents = payload.get("contents", "")
 
-        # Return a minimal valid ASG
+        # Ensure trailing newline to satisfy parser requirements
+        if contents and not contents.endswith("\n"):
+            contents += "\n"
+
+        # Invoke the parser (TASK-2.2 / Issue #38)
+        # The returned AST is stored in the 'ast' variable.
+        ast = parse_to_ast(contents)
+
+        # For now, we return a hardcoded ASG-like dictionary as per TASK-2.4 / Issue #40.
+        # Once TASK-3 (ASGVisitor) is implemented, this will be replaced with
+        # the result of the ASGVisitor.
         asg = {
             "type": "document",
             "children": []
         }
+
+        # Implement stdout Writing (TASK-2.4 / Issue #40)
         print(json.dumps(asg))
         sys.exit(0)
+
     except Exception as e:
+        # Implement Basic Error Handling (TASK-2.3 / Issue #39)
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
This commit implements the TCK Adapter as specified in Task #36 and its subtasks #37, #38, #39, and #40.

- Implement `stdin` parsing to extract the AsciiDoc source (Issue #37).
- Invoke the `parse_to_ast` function with the extracted source (Issue #38).
- Ensure a trailing newline is added to the source to satisfy parser requirements.
- Implement basic error handling to output errors to `stderr` and exit with a non-zero status code (Issue #39).
- Implement `stdout` writing to return a hardcoded ASG-like JSON dictionary (Issue #40).

Closes #36, #37, #38, #39, #40.