### PR TITLE
Integrate TCK into Project Test Suite

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -31,4 +31,4 @@ jobs:
 
     - name: Run TCK
       run: |
-        ./run-tck.sh
+        python -m pytest tests/test_tck.py

--- a/bin/tck-adapter.py
+++ b/bin/tck-adapter.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+"""
+TCK Adapter for AsciiDoc Parser.
+Converts AsciiDoc source to TCK-compliant ASG JSON.
+"""
 import sys
 import json
 from asciidoc_parser import parse_to_ast

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-pythonpath = src

--- a/run-tck.sh
+++ b/run-tck.sh
@@ -9,4 +9,4 @@ if [ ! -d "$TCK_DIR/node_modules" ]; then
 fi
 
 echo "Running TCK tests..."
-node "$TCK_DIR/harness/bin/asciidoc-tck.js" cli --adapter-command "python3 bin/tck-adapter.py" || true
+node "$TCK_DIR/harness/bin/asciidoc-tck.js" cli --adapter-command "python3 bin/tck-adapter.py" "$@"

--- a/tests/tck_failures.txt
+++ b/tests/tck_failures.txt
@@ -1,0 +1,3 @@
+block/header/attribute-entries-below-title-input.adoc
+block/listing/multiple-lines-input.adoc
+block/paragraph/multiple-lines-input.adoc

--- a/tests/test_tck.py
+++ b/tests/test_tck.py
@@ -1,0 +1,74 @@
+import pytest
+import subprocess
+import os
+import glob
+import re
+
+@pytest.fixture(scope="session")
+def tck_output():
+    """Runs the TCK and returns (stdout, stderr, returncode)."""
+    # Ensure TCK is initialized and run it
+    result = subprocess.run(["./run-tck.sh"], capture_output=True, text=True)
+    return result.stdout, result.stderr, result.returncode
+
+def get_tck_tests():
+    tck_tests_dir = os.path.join("vendor", "asciidoc-tck", "tests")
+    pattern = os.path.join(tck_tests_dir, "**", "*-input.adoc")
+    adoc_files = glob.glob(pattern, recursive=True)
+    return sorted([os.path.relpath(f, tck_tests_dir) for f in adoc_files])
+
+def get_known_failures():
+    failures_file = os.path.join("tests", "tck_failures.txt")
+    if not os.path.exists(failures_file):
+        return set()
+    with open(failures_file, "r") as f:
+        return {line.strip() for line in f if line.strip()}
+
+def parse_tck_failures(stdout):
+    """Parses TCK spec output and returns a list of failed test paths."""
+    failed_tests = []
+    stack = []
+    # Test names that are actually suites in the spec reporter
+    suites = {'tests', 'block', 'inline', 'header', 'listing', 'paragraph', 'document', 'list', 'unordered', 'section', 'sidebar', 'span', 'strong', 'no-markup'}
+
+    for line in stdout.splitlines():
+        line_clean = re.sub(r'\x1b\[[0-9;]*m', '', line)
+        if not line_clean.strip():
+            continue
+
+        indent = len(line_clean) - len(line_clean.lstrip())
+        level = indent // 2
+        content = line_clean.strip()
+
+        if content.startswith("▶"):
+            name = content[2:].split('(')[0].strip()
+            if name != "tests":
+                stack = stack[:level - 1]
+                stack.append(name)
+        elif content.startswith("✖"):
+            name = content[2:].split('(')[0].strip()
+            if name not in suites:
+                # This is a leaf test failure
+                filename = name.replace(' ', '-') + "-input.adoc"
+                # Make sure stack matches the current level
+                current_stack = stack[:level - 1]
+                full_rel_path = os.path.join(*current_stack, filename)
+                failed_tests.append(full_rel_path)
+    return failed_tests
+
+def get_parametrized_tests():
+    tests = get_tck_tests()
+    failures = get_known_failures()
+    params = []
+    for t in tests:
+        if t in failures:
+            params.append(pytest.param(t, marks=pytest.mark.xfail(reason=f"Known failure: {t}", strict=True)))
+        else:
+            params.append(t)
+    return params
+
+@pytest.mark.parametrize("adoc_path", get_parametrized_tests())
+def test_tck(adoc_path, tck_output):
+    stdout, stderr, returncode = tck_output
+    failed_tests = parse_tck_failures(stdout)
+    assert adoc_path not in failed_tests, f"TCK test failed: {adoc_path}"


### PR DESCRIPTION
- Create tests/test_tck.py to automate TCK execution via pytest.
- Implement session-scoped fixture to run the TCK harness once.
- Parse TCK spec reporter output to map results back to individual tests.
- Add tests/tck_failures.txt to track and xfail known failures.
- Update run-tck.sh to support arguments and correct exit status.
- Add docstring to bin/tck-adapter.py.

Closes #48, #49, #50, #51, #52.