### PR TITLE
Fix TCK suite errors, improve AST consistency, and enforce literal mo…

### DIFF
--- a/bin/tck-adapter.py
+++ b/bin/tck-adapter.py
@@ -35,12 +35,7 @@ def main():
 
         def clean_asg_for_tck(obj):
             if isinstance(obj, dict):
-                # TCK doesn't expect 'form' in spans
-                res = {
-                    k: clean_asg_for_tck(v)
-                    for k, v in obj.items()
-                    if k != "form"
-                }
+                res = {k: clean_asg_for_tck(v) for k, v in obj.items()}
                 # TCK prefers omitting empty child collections in some contexts
                 for key in ["blocks", "inlines", "items"]:
                     if key in res and not res[key]:
@@ -61,12 +56,6 @@ def main():
             output = clean_asg_for_tck(asg)
 
         result_json = json.dumps(output)
-        
-        # DEBUG LOGGING
-        with open("tck_debug.log", "a", encoding="utf-8") as f:
-            f.write(f"--- TEST TYPE: {parse_type} ---\n")
-            f.write(f"INPUT:\n{contents}\n")
-            f.write(f"OUTPUT:\n{result_json}\n\n")
 
         print(result_json)
         sys.exit(0)

--- a/debug_tck_mismatch.py
+++ b/debug_tck_mismatch.py
@@ -1,7 +1,8 @@
+import json
+
 from asciidoc_parser.lark_parser import parse_to_ast
 from asciidoc_parser.resolver import ASGResolver
-import json
-import os
+
 
 def remove_location(obj):
     if isinstance(obj, dict):
@@ -10,6 +11,7 @@ def remove_location(obj):
         return [remove_location(i) for i in obj]
     else:
         return obj
+
 
 source = "single word\n"
 ast = parse_to_ast(source)
@@ -31,8 +33,9 @@ if actual_clean == expected_clean:
 else:
     print("MISMATCH")
     import difflib
+
     diff = difflib.ndiff(
         json.dumps(expected_clean, indent=2).splitlines(),
-        json.dumps(actual_clean, indent=2).splitlines()
+        json.dumps(actual_clean, indent=2).splitlines(),
     )
     print("\n".join(diff))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 "Bug Tracker" = "https://github.com/webmaven/asciidoc_parser/issues"
 
 [project.optional-dependencies]
-test = ["pytest", "ruff", "mypy", "docutils", "types-docutils"]
+test = ["pytest", "ruff", "mypy", "docutils", "types-docutils", "sphinx"]
 docs = ["sphinx", "sphinx-rtd-theme"]
 
 [tool.pytest.ini_options]
@@ -48,7 +48,3 @@ python_version = "3.12"
 strict = true
 packages = ["asciidoc_parser"]
 ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "sphinx.*"
-ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,11 @@ select = ["E", "F", "I"]
 quote-style = "double"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.12"
 strict = true
 packages = ["asciidoc_parser"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "sphinx.*"
+ignore_errors = true

--- a/src/asciidoc_parser/docutils_backend.py
+++ b/src/asciidoc_parser/docutils_backend.py
@@ -2,7 +2,7 @@
 Converts the AsciiDoc AST to a Docutils document tree.
 """
 
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Optional, Union
 
 from docutils import nodes
 from docutils.frontend import OptionParser
@@ -10,29 +10,21 @@ from docutils.utils import new_document
 
 from .nodes import (
     Admonition,
-    BlockNode,
     Document,
-    Example,
-    Header,
     Image,
-    List as ASTList,
-    ListItem,
     Listing,
-    Node,
+    ListItem,
     NodeVisitor,
     Paragraph,
-    Quote,
     Ref,
-    Revision,
     Section,
     Sidebar,
     Span,
-    Table,
-    TableCell,
-    TableRow,
     Text,
     ThematicBreak,
-    Title,
+)
+from .nodes import (
+    List as ASTList,
 )
 
 
@@ -41,12 +33,12 @@ class DocutilsRenderer(NodeVisitor):
         self.document = document
         self.current_node: nodes.Element = document
 
-    def visit_document(self, node: Document):
-        if node.header and node.header.title:
+    def visit_document(self, node: Document) -> None:
+        if node.header and (header_title := node.header.title):
             title = nodes.title()
             old_parent = self.current_node
             self.current_node = title
-            for inline in node.header.title.inlines:
+            for inline in header_title.inlines:
                 self.visit(inline)
             self.document += title
             self.current_node = old_parent
@@ -54,7 +46,7 @@ class DocutilsRenderer(NodeVisitor):
         for block in node.blocks:
             self.visit(block)
 
-    def visit_section(self, node: Section):
+    def visit_section(self, node: Section) -> None:
         section = nodes.section()
         # Always ensure an ID exists for Sphinx/Docutils
         if "id" in node.attributes:
@@ -64,8 +56,9 @@ class DocutilsRenderer(NodeVisitor):
         title = nodes.title()
         old_parent = self.current_node
         self.current_node = title
-        for inline in node.title.inlines:
-            self.visit(inline)
+        if node.title:
+            for inline in node.title.inlines:
+                self.visit(inline)
         section += title
 
         self.current_node = section
@@ -75,7 +68,7 @@ class DocutilsRenderer(NodeVisitor):
         old_parent += section
         self.current_node = old_parent
 
-    def visit_paragraph(self, node: Paragraph):
+    def visit_paragraph(self, node: Paragraph) -> None:
         para = nodes.paragraph()
         old_parent = self.current_node
         self.current_node = para
@@ -84,10 +77,10 @@ class DocutilsRenderer(NodeVisitor):
         old_parent += para
         self.current_node = old_parent
 
-    def visit_text(self, node: Text):
+    def visit_text(self, node: Text) -> None:
         self.current_node += nodes.Text(node.value)
 
-    def visit_span(self, node: Span):
+    def visit_span(self, node: Span) -> None:
         mapping = {
             "strong": nodes.strong,
             "emphasis": nodes.emphasis,
@@ -105,7 +98,8 @@ class DocutilsRenderer(NodeVisitor):
         old_parent += span_node
         self.current_node = old_parent
 
-    def visit_list(self, node: ASTList):
+    def visit_list(self, node: ASTList) -> None:
+        list_node: Union[nodes.bullet_list, nodes.enumerated_list]
         if node.variant == "ordered":
             list_node = nodes.enumerated_list()
         else:
@@ -118,7 +112,7 @@ class DocutilsRenderer(NodeVisitor):
         old_parent += list_node
         self.current_node = old_parent
 
-    def visit_listitem(self, node: ListItem):
+    def visit_listitem(self, node: ListItem) -> None:
         item = nodes.list_item()
         old_parent = self.current_node
         self.current_node = item
@@ -137,7 +131,7 @@ class DocutilsRenderer(NodeVisitor):
         old_parent += item
         self.current_node = old_parent
 
-    def visit_ref(self, node: Ref):
+    def visit_ref(self, node: Ref) -> None:
         # Handle cross-references and links
         ref_node = nodes.reference()
 
@@ -146,7 +140,8 @@ class DocutilsRenderer(NodeVisitor):
         if node.variant == "link":
             ref_node["refuri"] = target
         elif node.variant == "xref":
-            # If target looks like a filename without extension, assume .html for Sphinx/HTML
+            # If target looks like a filename without extension, assume .html for
+            # Sphinx/HTML
             if "." not in target and "/" not in target:
                 target = target + ".html"
             else:
@@ -162,7 +157,7 @@ class DocutilsRenderer(NodeVisitor):
         old_parent += ref_node
         self.current_node = old_parent
 
-    def visit_listing(self, node: Listing):
+    def visit_listing(self, node: Listing) -> None:
         content = "".join(
             [getattr(n, "value", "") for n in node.inlines if hasattr(n, "value")]
         )
@@ -171,8 +166,8 @@ class DocutilsRenderer(NodeVisitor):
             literal["classes"].append(node.attributes["language"])
         self.current_node += literal
 
-    def visit_admonition(self, node: Admonition):
-        mapping = {
+    def visit_admonition(self, node: Admonition) -> None:
+        mapping: Any = {
             "note": nodes.note,
             "tip": nodes.tip,
             "important": nodes.important,
@@ -189,14 +184,14 @@ class DocutilsRenderer(NodeVisitor):
         old_parent += adm
         self.current_node = old_parent
 
-    def visit_image(self, node: Image):
+    def visit_image(self, node: Image) -> None:
         img = nodes.image(uri=node.target, alt=node.attributes.get("alt", ""))
         self.current_node += img
 
-    def visit_thematic_break(self, node: ThematicBreak):
-        self.current_node += nodes.thematic_break()
+    def visit_thematic_break(self, node: ThematicBreak) -> None:
+        self.current_node += nodes.transition()
 
-    def visit_sidebar(self, node: Sidebar):
+    def visit_sidebar(self, node: Sidebar) -> None:
         sb = nodes.sidebar()
         if node.title:
             title = nodes.title()

--- a/src/asciidoc_parser/grammar.lark
+++ b/src/asciidoc_parser/grammar.lark
@@ -84,7 +84,7 @@ page_break: "<<<" _NEWLINE
 text_content: inline_element+
 
 attribute_reference.2: LBRACE ATTR_NAME RBRACE
-?inline_element: unconstrained_bold | bold | unconstrained_italic | italic | unconstrained_monospace | monospace | attribute_reference | inline_attribute_list | marked | superscript | subscript | footnote | footnoteref | double_quoted | single_quoted | inline_image | icon_inline | inline_anchor | inline_xref | inline_bibref | WHITESPACE | COLON | WORD | LBRACE | RBRACE | EQUALS | LSQB | RSQB
+?inline_element: unconstrained_bold | bold | unconstrained_italic | italic | unconstrained_monospace | monospace | attribute_reference | inline_attribute_list | marked | superscript | subscript | footnote | footnoteref | double_quoted | single_quoted | inline_image | icon_inline | inline_anchor | inline_xref | inline_bibref | WHITESPACE | COLON | WORD | LBRACE | RBRACE | EQUALS | LSQB | RSQB | BACKTICK
 
 image_block: "image::" TARGET "[" [ATTR_LIST_CONTENT] "]" _NEWLINE
 inline_image: "image:" TARGET inline_attribute_list
@@ -106,6 +106,7 @@ bold: "*" text_content "*"
 unconstrained_bold.2: "**" text_content "**"
 italic: "_" text_content "_"
 unconstrained_italic.2: "__" text_content "__"
+
 monospace: "`" monospace_content "`"
 unconstrained_monospace.2: "``" unconstrained_monospace_content "``"
 
@@ -114,6 +115,7 @@ unconstrained_monospace_content: (attribute_reference | UNCONSTRAINED_MONOSPACE_
 
 MONOSPACE_TEXT: /[^`{\n]+/ | "{"
 UNCONSTRAINED_MONOSPACE_TEXT: /([^`{\n]|`[^`])+/ | "{"
+
 marked: "#" text_content "#"
 superscript: "^" text_content "^"
 subscript: "~" text_content "~"
@@ -155,6 +157,7 @@ RBRACE: "}"
 LSQB: "["
 RSQB: "]"
 EQUALS: "="
+BACKTICK: "`"
 COLON: ":"
 
 // %ignore WHITESPACE

--- a/src/asciidoc_parser/grammar.lark
+++ b/src/asciidoc_parser/grammar.lark
@@ -83,8 +83,8 @@ page_break: "<<<" _NEWLINE
 // Using a recursive definition. Requires the Earley parser.
 text_content: inline_element+
 
-attribute_reference: LBRACE ATTR_NAME RBRACE
-?inline_element: unconstrained_bold | bold | unconstrained_italic | italic | unconstrained_monospace | monospace | attribute_reference | inline_attribute_list | marked | superscript | subscript | footnote | footnoteref | double_quoted | single_quoted | inline_image | icon_inline | inline_anchor | inline_xref | inline_bibref | WHITESPACE | COLON | WORD
+attribute_reference.2: LBRACE ATTR_NAME RBRACE
+?inline_element: unconstrained_bold | bold | unconstrained_italic | italic | unconstrained_monospace | monospace | attribute_reference | inline_attribute_list | marked | superscript | subscript | footnote | footnoteref | double_quoted | single_quoted | inline_image | icon_inline | inline_anchor | inline_xref | inline_bibref | WHITESPACE | COLON | WORD | LBRACE | RBRACE | EQUALS | LSQB | RSQB
 
 image_block: "image::" TARGET "[" [ATTR_LIST_CONTENT] "]" _NEWLINE
 inline_image: "image:" TARGET inline_attribute_list
@@ -106,8 +106,14 @@ bold: "*" text_content "*"
 unconstrained_bold.2: "**" text_content "**"
 italic: "_" text_content "_"
 unconstrained_italic.2: "__" text_content "__"
-monospace: "`" text_content "`"
-unconstrained_monospace.2: "``" text_content "``"
+monospace: "`" monospace_content "`"
+unconstrained_monospace.2: "``" unconstrained_monospace_content "``"
+
+monospace_content: (attribute_reference | MONOSPACE_TEXT)+
+unconstrained_monospace_content: (attribute_reference | UNCONSTRAINED_MONOSPACE_TEXT)+
+
+MONOSPACE_TEXT: /[^`{\n]+/ | "{"
+UNCONSTRAINED_MONOSPACE_TEXT: /([^`{\n]|`[^`])+/ | "{"
 marked: "#" text_content "#"
 superscript: "^" text_content "^"
 subscript: "~" text_content "~"
@@ -119,15 +125,15 @@ single_quoted: "'`" text_content "`'"
 
 // Block Terminals
 DOC_TITLE_LEAD: /= [ \t]*/
-SECTION_TITLE_LEAD: /==+ [ \t]*/
+SECTION_TITLE_LEAD.2: /==+ [ \t]*/
 ULIST_MARKER: /(\*+|[-])[ \t]+/
 OLIST_MARKER: /([0-9]+\.|[\.]+)[ \t]+/
 LITERAL_BLOCK_DELIM.2: /-{4,}/
 ADMONITION_START: /\[ *(NOTE|TIP|IMPORTANT|WARNING|CAUTION) *\]/
 
-ADMONITION_DELIM_4: "===="
-ADMONITION_DELIM_5: "====="
-ADMONITION_DELIM_6: "======"
+ADMONITION_DELIM_4.2: "===="
+ADMONITION_DELIM_5.2: "====="
+ADMONITION_DELIM_6.2: "======"
 ADMONITION_DELIM_LONG: /={7,}/
 
 SIDEBAR_DELIM_4: "****"
@@ -146,6 +152,9 @@ ATTR_NAME: /[a-zA-Z0-9_\-]+/
 WORD: /[^ \t\n*_`=\[\]{}:]+/  // Word characters (not whitespace or markup)
 LBRACE: "{"
 RBRACE: "}"
+LSQB: "["
+RSQB: "]"
+EQUALS: "="
 COLON: ":"
 
 // %ignore WHITESPACE

--- a/src/asciidoc_parser/lark_parser.py
+++ b/src/asciidoc_parser/lark_parser.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Any, Dict, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
 from typing import List as PyList
 
 from lark import Discard, Lark, Token, Transformer
@@ -17,7 +17,6 @@ from .nodes import (
     PageBreak,
     Revision,
     Section,
-    Ref,
     Text,
     ThematicBreak,
     Title,

--- a/src/asciidoc_parser/nodes.py
+++ b/src/asciidoc_parser/nodes.py
@@ -350,10 +350,7 @@ class ListItem(BlockNode):
     """A node representing a single item within a list. It can contain blocks."""
 
     def get_child_collections(self) -> Dict[str, PyList[Node]]:
-        res: Dict[str, PyList[Node]] = {"principal": self.principal}
-        if self.blocks:
-            res["blocks"] = self.blocks
-        return res
+        return {"principal": self.principal, "blocks": self.blocks}
 
     def __init__(
         self,

--- a/src/asciidoc_parser/preprocessor.py
+++ b/src/asciidoc_parser/preprocessor.py
@@ -56,7 +56,8 @@ class Preprocessor:
                     os.path.join(current_dir, include_path)
                 )
 
-                # Security check: verify target is within base directory if safe_mode is on
+                # Security check: verify target is within base directory if
+                # safe_mode is on
                 if (
                     self.safe_mode
                     and os.path.commonprefix([target_file_path, self.base_dir])

--- a/src/asciidoc_parser/sphinx_ext.py
+++ b/src/asciidoc_parser/sphinx_ext.py
@@ -1,7 +1,9 @@
-from typing import Any, Dict, Optional
 import os
-from sphinx.parsers import Parser as SphinxParser
+from typing import Any, Dict
+
 from docutils import nodes
+from sphinx.parsers import Parser as SphinxParser
+
 from .docutils_backend import DocutilsRenderer
 from .lark_parser import parse_to_ast
 
@@ -11,7 +13,7 @@ class AsciiDocParser(SphinxParser):
     Sphinx parser for AsciiDoc files.
     """
 
-    supported: tuple[str, ...] = ("asciidoc", "adoc")
+    supported: tuple[str, ...] = ("asciidoc", "adoc")  # type: ignore[misc]
 
     def parse(self, inputstring: str, document: nodes.document) -> None:
         """
@@ -28,7 +30,8 @@ class AsciiDocParser(SphinxParser):
 
         try:
             # We parse to our custom AST first
-            # Disable safe_mode for Sphinx builds to allow including files from project root
+            # Disable safe_mode for Sphinx builds to allow including files from
+            # project root
             ast = parse_to_ast(inputstring, base_dir=base_dir, safe_mode=False)
 
             # Then we use our new DocutilsRenderer to populate the Sphinx/Docutils tree

--- a/src/asciidoc_parser/transformers/inline_transformer.py
+++ b/src/asciidoc_parser/transformers/inline_transformer.py
@@ -113,17 +113,17 @@ class InlineTransformer:
     def literal_content(self, children: PyList[Any]) -> str:
         return str(children[0])
 
+    def monospace_content(self, children: PyList[Any]) -> PyList[Node]:
+        return self.text_content(children)
+
+    def unconstrained_monospace_content(self, children: PyList[Any]) -> PyList[Node]:
+        return self.text_content(children)
+
     def monospace(self, children: PyList[Any]) -> Span:
-        content = [c for c in children if isinstance(c, list)]
-        return Span(
-            variant="code", form="constrained", inlines=content[0] if content else []
-        )
+        return Span(variant="code", form="constrained", inlines=children[0])
 
     def unconstrained_monospace(self, children: PyList[Any]) -> Span:
-        content = [c for c in children if isinstance(c, list)]
-        return Span(
-            variant="code", form="unconstrained", inlines=content[0] if content else []
-        )
+        return Span(variant="code", form="unconstrained", inlines=children[0])
 
     def marked(self, children: PyList[Any]) -> Span:
         return Span(variant="mark", inlines=children[0] if children else [])

--- a/tests/test_combined.py
+++ b/tests/test_combined.py
@@ -14,6 +14,7 @@ Another paragraph.
 """
         ast = parse_to_ast(source).to_dict()
         import json
+
         print(json.dumps(ast, indent=2))
         self.maxDiff = None
         expected_ast = {

--- a/tests/test_doc_build_discoveries.py
+++ b/tests/test_doc_build_discoveries.py
@@ -37,6 +37,21 @@ class TestDocBuildDiscoveries(unittest.TestCase):
         self.assertEqual(len(span["inlines"]), 1)
         self.assertEqual(span["inlines"][0]["value"], "asciidoc_parser.sphinx_ext")
 
+    def test_unconstrained_monospace_literal(self):
+        """
+        Unconstrained monospace backticks (``) should also be literal.
+        """
+        source = "``*bold* _italic_``\n"
+        ast = parse_to_ast(source).to_dict()
+        paragraph = ast["blocks"][0]
+        span = paragraph["inlines"][0]
+        self.assertEqual(span["variant"], "code")
+        self.assertEqual(span["form"], "unconstrained")
+
+        # The content should be a single text node with literal content
+        self.assertEqual(len(span["inlines"]), 1)
+        self.assertEqual(span["inlines"][0]["value"], "*bold* _italic_")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_doc_build_discoveries.py
+++ b/tests/test_doc_build_discoveries.py
@@ -1,0 +1,42 @@
+import unittest
+
+import pytest
+
+from asciidoc_parser.lark_parser import parse_to_ast
+
+
+class TestDocBuildDiscoveries(unittest.TestCase):
+    @pytest.mark.xfail(reason="Tables are not yet implemented")
+    def test_table_parsing(self):
+        source = """
+[cols="1,2"]
+|===
+| AST Node | ASG Structure
+| `Document` | document
+|===
+"""
+        # This currently raises a Lark error
+        ast = parse_to_ast(source).to_dict()
+        self.assertEqual(ast["blocks"][0]["name"], "table")
+
+    def test_monospace_with_underscores_no_nested_italics(self):
+        """
+        Monospace backticks should be literal and not allow nested formatting.
+        This verifies the fix for the behavior discovered in index.adoc.
+        """
+        source = "own `asciidoc_parser.sphinx_ext` plugin!\n"
+        ast = parse_to_ast(source).to_dict()
+        paragraph = ast["blocks"][0]
+        span = paragraph["inlines"][1]
+        self.assertEqual(span["variant"], "code")
+
+        # Check that it DOES NOT have nested emphasis
+        nested_variants = [n.get("variant") for n in span["inlines"] if "variant" in n]
+        self.assertNotIn("emphasis", nested_variants)
+        # The content should be a single text node
+        self.assertEqual(len(span["inlines"]), 1)
+        self.assertEqual(span["inlines"][0]["value"], "asciidoc_parser.sphinx_ext")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docutils_backend.py
+++ b/tests/test_docutils_backend.py
@@ -1,5 +1,5 @@
-import pytest
 from docutils import nodes
+
 from asciidoc_parser.docutils_backend import asciidoc_to_docutils
 
 
@@ -24,7 +24,8 @@ def test_basic_conversion():
 
     # Check inline nodes
     inline_nodes = para.children
-    # Expected: [Text('Testing '), strong(Text('bold')), Text(' and '), emphasis(Text('italic')), Text('.')]
+    # Expected: [Text('Testing '), strong(Text('bold')), Text(' and '),
+    # emphasis(Text('italic')), Text('.')]
     types = [type(c) for c in inline_nodes]
     assert nodes.strong in types
     assert nodes.emphasis in types

--- a/tests/test_tck.py
+++ b/tests/test_tck.py
@@ -12,7 +12,7 @@ def tck_output():
     """Runs the TCK and returns (stdout, stderr, returncode)."""
     tck_dir = os.path.join("vendor", "asciidoc-tck")
     node_modules = os.path.join(tck_dir, "node_modules")
-    
+
     # Ensure TCK is initialized
     if not os.path.exists(node_modules):
         subprocess.run(["npm", "ci"], cwd=tck_dir, check=True)
@@ -20,9 +20,9 @@ def tck_output():
     # Run TCK directly via node
     harness_path = os.path.join(tck_dir, "harness", "bin", "asciidoc-tck.js")
     adapter_cmd = f"{sys.executable} bin/tck-adapter.py"
-    
+
     cmd = ["node", harness_path, "cli", "--adapter-command", adapter_cmd]
-    
+
     result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
     return result.stdout, result.stderr, result.returncode
 


### PR DESCRIPTION
…nospace behavior

- Modified `bin/tck-adapter.py` to preserve the 'form' attribute in ASG output, required for TCK compliance.
- Updated `ListItem.get_child_collections` in `nodes.py` to always return the 'blocks' collection, fixing structural consistency.
- Redefined `monospace` and `unconstrained_monospace` in `grammar.lark` to be literal (ignoring nested formatting) while still allowing attribute references.
- Fixed general parsing of literal characters like `{`, `}`, `[`, `]`, and `=` in normal text.
- Resolved grammar ambiguities using rule priorities (e.g., `SECTION_TITLE_LEAD.2`, `attribute_reference.2`).
- Cleaned up all `ruff` linting and `mypy` type checking issues.
- Verified that all core tests, doctests, and TCK tests pass.