### PR TITLE
docs: Update ARCHITECTURE.adoc to match converged AST/ASG structure

### DIFF
--- a/ARCHITECTURE.adoc
+++ b/ARCHITECTURE.adoc
@@ -12,7 +12,9 @@ The project needs to produce a TCK-compliant Resolved Abstract Semantic Graph (A
 
 === Decision
 
-We will implement an `ASGVisitor` to transform the AST into the ASG. The mapping follows the official AsciiDoc ASG schema (https://gitlab.eclipse.org/eclipse/asciidoc-lang/asciidoc-lang/-/blob/main/asg/schema.json):
+We have converged the internal AST structure to match the ASG schema directly. Each node in `nodes.py` now implements a polymorphic `to_dict()` method that produces TCK-compliant output. Semantic resolution (attribute substitution, etc.) is handled by the `ASGResolver`.
+
+The mapping follows the official AsciiDoc ASG schema (https://gitlab.eclipse.org/eclipse/asciidoc-lang/asciidoc-lang/-/blob/main/asg/schema.json):
 
 [cols="1,2"]
 |===
@@ -22,42 +24,36 @@ We will implement an `ASGVisitor` to transform the AST into the ASG. The mapping
 | `{"name": "document", "type": "block", "blocks": [], "attributes": {}, "header": {}}`
 
 | `Paragraph`
-| `{"name": "paragraph", "type": "block", "form": "paragraph", "inlines": []}`
+| `{"name": "paragraph", "type": "block", "inlines": []}`
 
 | `Text`
 | `{"name": "text", "type": "string", "value": "text content"}`
 
-| `Strong`
-| `{"name": "span", "type": "inline", "variant": "strong", "form": "constrained", "inlines": []}`
-
-| `Emphasis`
-| `{"name": "span", "type": "inline", "variant": "emphasis", "form": "constrained", "inlines": []}`
-
-| `InlineCode`
-| `{"name": "span", "type": "inline", "variant": "code", "form": "constrained", "inlines": []}`
+| `Span`
+| `{"name": "span", "type": "inline", "variant": "strong|emphasis|code", "form": "constrained", "inlines": []}`
 
 | `Section`
 | `{"name": "section", "type": "block", "level": 1, "title": [], "blocks": []}`
 
-| `BulletList`
-| `{"name": "list", "type": "block", "variant": "unordered", "marker": "*", "items": []}`
+| `List`
+| `{"name": "list", "type": "block", "variant": "unordered|ordered", "marker": "*|.", "items": []}`
 
 | `ListItem`
 | `{"name": "listItem", "type": "block", "principal": [], "blocks": []}`
 
-| `LiteralBlock`
+| `Listing`
 | `{"name": "listing", "type": "block", "form": "delimited", "delimiter": "----", "inlines": []}`
 
-| `Link`
+| `Ref`
 | `{"name": "ref", "type": "inline", "variant": "link", "target": "url", "inlines": []}`
 |===
 
 === Rationale
 
-The official ASG schema is the authoritative source for the structure of the Resolved Abstract Semantic Graph. Aligning our visitor with this schema ensures compatibility with the TCK and other tools in the AsciiDoc ecosystem.
+The official ASG schema is the authoritative source for the structure of the Resolved Abstract Semantic Graph. Directly aligning the AST with this schema eliminates the need for a complex transformation layer, reducing maintenance burden and ensuring that the parser always produces spec-compliant output.
 
 === Consequences
 
-- The `ASGVisitor` must be kept in sync with any updates to the official ASG schema.
-- The visitor handles the transformation of complex nodes like lists and tables by mapping their internal structure to the schema's requirements (e.g., `principal` vs `blocks` in list items).
-- Some fields (like `form` and `delimiter`) are currently hardcoded based on the parser's standard behavior but should ideally be derived from the AST if the parser is updated to capture them.
+- New node types added to `nodes.py` must follow the ASG schema naming conventions.
+- The `to_dict()` method must be kept in sync with any updates to the official ASG schema.
+- Semantic resolution logic (e.g., attribute substitution) is centralized in `resolver.py` and operates on the structured AST before final serialization.


### PR DESCRIPTION
Reflects the removal of ASGVisitor and the adoption of polymorphic to_dict() methods for ASG serialization. Closes #42.